### PR TITLE
feat: add architect chatmode for detailed planning and documentation

### DIFF
--- a/.github/chatmodes/architect.chatmode.md
+++ b/.github/chatmodes/architect.chatmode.md
@@ -1,0 +1,29 @@
+---
+description: Architect or technical leader mode.
+tools: ['codebase', 'editFiles', 'fetch', 'findTestFiles', 'search']
+---
+
+## Description
+You are Archy, an experienced architect and technical lead who is inquisitive, pragmatic, and an excellent planner. 
+Your goal is to gather information and get context to create a detailed plan for accomplishing the user's task. 
+The user will review and approve the plan before switching into another mode to implement the solution.
+**Important Notice:**
+
+This chatmode is strictly limited to Markdown (.md) files.
+
+- You may only view, create, or edit Markdown files in this workspace.
+- Any attempt to modify, rename, or delete non-Markdown files will be rejected.
+- All architectural guidance, documentation, and design artifacts must be written in Markdown format.
+
+If you need to make changes to code or non-Markdown files, please switch to a different chatmode or use the appropriate tools.
+
+## Custom Instructions
+1. Do some information gathering (for example using read_file or search) to get more context about the task.
+2. Ask the user clarifying questions to get a better understanding of the task.
+3. Once you've gained more context about the user's request, create a detailed plan for how to accomplish the task. Include Mermaid diagrams if they help make your plan clearer.
+4. Ask the user if they are pleased with this plan, or if they would like to make any changes. Treat this as a brainstorming session to discuss and refine the plan.
+5. Once the user confirms the plan, ask if they'd like you to write it to a Markdown file.
+6. Use the switch_mode tool to request that the user switch to another mode to implement the solution.
+
+**Reminder:** All outputs and plans must be written in Markdown files only.
+

--- a/README.md
+++ b/README.md
@@ -36,8 +36,21 @@ This project provides a set of best practices, coding rules, and prompt instruct
 
 - `.github/instructions/` — All coding rules and best practices (Markdown)
 - `.github/prompts/` — Prompt files for Copilot and AI tools
+- `.github/chatmodes/` — Chatmode files to configure Copilot/AI behavior (e.g. `architect`)
 - `.github/copilot-instructions.md` — Main Copilot and C# workflow rules
 - `README.md` — This file
+
+## 🧑‍💼 What is a chatmode? (Only available to Visual Studio Insiders)
+
+A **chatmode** is a configuration file (in `.github/chatmodes/`) that defines how Copilot or another AI assistant should behave in a specific context or workflow. For example, the `architect` chatmode makes the AI act as an experienced architect and technical lead, focusing on planning, documentation, and Markdown-only outputs. Chatmodes can set the tone, priorities, and constraints for the AI during a session or project.
+
+## 📏 What is an instruction?
+
+An **instruction** is a Markdown file (in `.github/instructions/`) that defines coding rules, architectural standards, and best practices for the project. Instructions are always active and must be followed for all code and documentation generated in the repository. They ensure consistency, maintainability, and alignment with the project's technical vision (e.g., DDD, testing, commit conventions).
+
+## 💡 What is a prompt?
+
+A **prompt** is a template or guidance file (in `.github/prompts/`) used to help Copilot or another AI tool generate code or documentation in a specific style or for a particular use case. Prompts are reusable and can steer the AI in a particular direction for a given task, such as enforcing TDD, writing API documentation, or generating test cases.
 
 ## 🧑‍💻 How to contribute
 


### PR DESCRIPTION
## 📑 Description
# Add support for chatmodes (Visual Studio Insiders only)

## Summary

This PR introduces the concept of **chatmodes** to the repository.  
A chatmode is a configuration file (in `.github/chatmodes/`) that defines how Copilot or another AI assistant should behave in a specific context or workflow.  
For example, the new `architect` chatmode configures the AI to act as an experienced architect, focusing on planning, documentation, and Markdown-only outputs.

> **Note:** This feature is currently only available in GitHub Copilot Insiders.

## Details

- Added `.github/chatmodes/architect.chatmode.md` with a description and custom workflow.
- Updated `README.md` to explain:
  - What is a chatmode?
  - What is an instruction?
  - What is a prompt?
- Clarified the repository structure and documentation for these new concepts.

## Motivation

- Enables more flexible and context-aware AI assistance.
- Improves onboarding and documentation for teams using Copilot in advanced workflows.
- Prepares the repository for future public availability of chatmodes.

## How to test

- Select the `architect` chatmode in your Copilot/AI tool and verify that the assistant follows the described workflow.

Let me know if you have any questions or suggestions!

> <img width="912" alt="image" src="https://github.com/user-attachments/assets/1c200ae9-76ff-45b5-9384-c70b2de20332" />


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
- Requires Visual Studio Insiders with chatmode support enabled.
