### PR TITLE
Test/eval

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -49,7 +49,7 @@ on:
       model:
         description: 'LLM model to use'
         type: string
-        default: 'gpt-4o'
+        default: 'gpt-4.1'
   schedule:
     - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC
 
@@ -466,7 +466,7 @@ jobs:
           ASSET_KIND: ${{ matrix.entry.kind }}
           ASSET_PATH: ${{ matrix.entry.assetPath }}
           TEST_PATH: ${{ matrix.entry.testPath }}
-          MODEL: ${{ inputs.model || 'gpt-4o' }}
+          MODEL: ${{ inputs.model || 'gpt-4.1' }}
           IS_FORK: ${{ needs.discover.outputs.is-fork }}
           HEAD_SHA: ${{ needs.discover.outputs.head-sha }}
           EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -461,7 +461,7 @@ jobs:
 
       - name: Run evaluation
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_TOKEN }}
           ASSET_ID: ${{ matrix.entry.id }}
           ASSET_KIND: ${{ matrix.entry.kind }}
           ASSET_PATH: ${{ matrix.entry.assetPath }}

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -463,6 +463,7 @@ jobs:
         env:
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
           OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
+          GITHUB_TOKEN: ${{ github.token }}
           ASSET_ID: ${{ matrix.entry.id }}
           ASSET_KIND: ${{ matrix.entry.kind }}
           ASSET_PATH: ${{ matrix.entry.assetPath }}
@@ -513,7 +514,6 @@ jobs:
           npx tsx src/index.ts evaluate \
             --entries "${ENTRIES_FILE}" \
             --model "${MODEL}" \
-            --provider openai \
             --output "${RUNNER_TEMP}/results" \
             --repo-root "${REPO_ROOT}" \
             --source "${SOURCE}" \

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -513,6 +513,7 @@ jobs:
           npx tsx src/index.ts evaluate \
             --entries "${ENTRIES_FILE}" \
             --model "${MODEL}" \
+            --provider openai \
             --output "${RUNNER_TEMP}/results" \
             --repo-root "${REPO_ROOT}" \
             --source "${SOURCE}" \

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -461,9 +461,7 @@ jobs:
 
       - name: Run evaluation
         env:
-          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-          OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ASSET_ID: ${{ matrix.entry.id }}
           ASSET_KIND: ${{ matrix.entry.kind }}
           ASSET_PATH: ${{ matrix.entry.assetPath }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ website/.env.local
 tools/evaluator/node_modules/
 tools/evaluator/dist/
 tools/evaluator/coverage/
+
+# Local worktrees
+.worktrees/

--- a/docs/superpowers/plans/2026-04-16-copilot-sdk-evaluator-implementation.md
+++ b/docs/superpowers/plans/2026-04-16-copilot-sdk-evaluator-implementation.md
@@ -1,0 +1,447 @@
+# Copilot SDK Evaluator Provider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Copilot SDK as the default LLM provider in the evaluator while preserving OpenAI as an explicit compatibility provider.
+
+**Architecture:** Introduce a provider-aware `LLMClient` factory in the adapter layer and keep `runner`/`judge` provider-agnostic. Implement Copilot session handling in a dedicated adapter that maps usage to existing input/output token fields and throws explicit provider errors with no fallback.
+
+**Tech Stack:** TypeScript, Node.js, Vitest, Commander CLI, OpenAI SDK, GitHub Copilot SDK
+
+---
+
+## File Structure
+
+- `tools/evaluator/src/adapters/llm-client.ts`
+  Shared contracts (`LLMClient`, options, response), provider type, and provider factory.
+
+- `tools/evaluator/src/adapters/llm/openai-client.ts`
+  OpenAI-backed `LLMClient` implementation extracted from current monolithic adapter.
+
+- `tools/evaluator/src/adapters/llm/copilot-client.ts`
+  Copilot SDK-backed `LLMClient` implementation with session/event handling, timeout, and token mapping.
+
+- `tools/evaluator/src/cli.ts`
+  Adds `--provider <copilot|openai>` to `evaluate`, defaults to `copilot`, and applies provider-aware validation.
+
+- `tools/evaluator/src/core/runner.ts`
+  Must continue receiving a generic `LLMClient` only (no provider branching).
+
+- `tools/evaluator/src/core/judge.ts`
+  Must continue using `LLMClient` methods only; provider-specific behavior remains in adapters.
+
+- `tools/evaluator/package.json`
+  Adds `@github/copilot-sdk` dependency used by Copilot adapter.
+
+- `tools/evaluator/__tests__/llm-client-factory.test.ts`
+  New tests for provider dispatch, defaulting behavior contract, and unsupported provider errors.
+
+- `tools/evaluator/__tests__/evaluate-provider.integration.test.ts`
+  New command-level tests for provider defaulting, copilot fail-fast, and no-fallback behavior.
+
+- `tools/evaluator/__tests__/copilot-client.test.ts`
+  New tests for Copilot token mapping, timeout, empty response, and explicit failures.
+
+- `tools/evaluator/__tests__/cli-provider.test.ts`
+  New tests for CLI provider parsing and provider-aware env validation.
+
+- `tools/evaluator/__tests__/runner.test.ts`
+  Extend to assert the runner remains provider-agnostic and consumes `LLMClient` only.
+
+- `tools/evaluator/__tests__/judge.test.ts`
+  Extend to lock behavior when `completeWithTools` is unsupported by the selected provider.
+
+## Testing Strategy
+
+- Outside-in first for CLI provider selection and evaluate flow behavior.
+- Then adapter-level unit tests for Copilot/OpenAI provider contracts.
+- Keep token schema assertions strict: only `tokensInput` and `tokensOutput` are persisted.
+- Validate explicit failure behavior and the absence of fallback path.
+
+## Task 1: Lock Provider Selection Behavior With Failing CLI Tests
+
+**Files:**
+- Create: `tools/evaluator/__tests__/cli-provider.test.ts`
+- Modify: `tools/evaluator/src/cli.ts` (later task)
+
+- [ ] **Step 1: Add failing tests for default provider and explicit provider values**
+
+Create tests such as:
+
+```ts
+it('uses copilot provider when --provider is omitted', async () => {
+  // execute evaluate command parsing with no --provider and assert selected provider is 'copilot'
+});
+
+it('accepts --provider openai', async () => {
+  // parse args and assert selected provider is 'openai'
+});
+
+it('fails fast for unsupported provider values', async () => {
+  // assert non-zero exit path and clear error message
+});
+```
+
+- [ ] **Step 2: Add failing tests for provider-aware env validation**
+
+```ts
+it('requires LLM_API_KEY when provider is openai', async () => {
+  // expect failure when key is absent
+});
+
+it('does not require LLM_API_KEY when provider is copilot', async () => {
+  // expect no env validation failure on key absence
+});
+```
+
+- [ ] **Step 3: Add failing command-level dispatch test before implementation**
+
+In `cli-provider.test.ts`, add a command-level evaluate-path test (with mocked `createLLMClient`) that asserts omitted `--provider` dispatches `provider: 'copilot'` into the factory.
+
+- [ ] **Step 4: Run tests to confirm red state**
+
+- [ ] **Step 3: Run tests to confirm red state**
+
+Run:
+
+```bash
+cd tools/evaluator
+npx vitest run __tests__/cli-provider.test.ts
+```
+
+Expected: FAIL because provider flag/default, command-level dispatch, and provider-aware validation are not implemented yet.
+
+- [ ] **Step 5: Commit red tests**
+
+```bash
+git add tools/evaluator/__tests__/cli-provider.test.ts
+git commit -S -m "test: lock evaluator provider cli behavior"
+```
+
+## Task 2: Extract OpenAI Provider And Add Provider Factory
+
+**Files:**
+- Modify: `tools/evaluator/src/adapters/llm-client.ts`
+- Create: `tools/evaluator/src/adapters/llm/openai-client.ts`
+- Create: `tools/evaluator/__tests__/llm-client-factory.test.ts`
+
+- [ ] **Step 1: Add failing tests for provider factory dispatch**
+
+Create tests such as:
+
+```ts
+it('returns openai client when provider=openai', () => {
+  const client = createLLMClient({ provider: 'openai', model: 'gpt-4o', apiKey: 'k' });
+  expect(client).toBeDefined();
+});
+
+it('throws provider_invalid for unknown provider', () => {
+  expect(() => createLLMClient({ provider: 'x' as never, model: 'gpt-4o' })).toThrow();
+});
+```
+
+- [ ] **Step 2: Extract current OpenAI implementation into dedicated file**
+
+Move current logic into `tools/evaluator/src/adapters/llm/openai-client.ts` and export a constructor used by the factory.
+
+- [ ] **Step 3: Update shared adapter contracts and provider-aware config**
+
+Define:
+
+```ts
+export type LLMProvider = 'copilot' | 'openai';
+
+export interface LLMClientConfig {
+  provider: LLMProvider;
+  model: string;
+  apiKey?: string;
+  baseURL?: string;
+  workDir?: string;
+  timeoutMs?: number;
+}
+```
+
+- [ ] **Step 4: Run tests for factory and legacy tests**
+
+Run:
+
+```bash
+cd tools/evaluator
+npx vitest run __tests__/llm-client-factory.test.ts __tests__/runner.test.ts __tests__/judge.test.ts
+```
+
+Expected: PASS for factory/openai dispatch tests; existing runner/judge tests still pass.
+
+- [ ] **Step 5: Commit extraction and factory**
+
+```bash
+git add tools/evaluator/src/adapters/llm-client.ts tools/evaluator/src/adapters/llm/openai-client.ts tools/evaluator/__tests__/llm-client-factory.test.ts
+git commit -S -m "refactor: introduce provider-based llm client factory"
+```
+
+## Task 3: Add Copilot Provider Tests First
+
+**Files:**
+- Create: `tools/evaluator/__tests__/copilot-client.test.ts`
+- Modify: `tools/evaluator/src/adapters/llm/copilot-client.ts` (later task)
+
+- [ ] **Step 1: Add failing token mapping tests**
+
+```ts
+it('maps copilot usage input/output to tokensInput/tokensOutput', async () => {
+  // mock usage events and assert sums map correctly
+});
+
+it('ignores cache token fields and persists only input/output totals', async () => {
+  // mock usage payload containing cache fields and assert output object only uses input/output
+});
+```
+
+- [ ] **Step 2: Add failing explicit error behavior tests**
+
+```ts
+it('throws provider_timeout when session does not become idle before timeout', async () => {
+  // expect explicit timeout category in error message
+});
+
+it('throws provider_empty_response when assistant content is empty', async () => {
+  // expect explicit category in error message
+});
+
+it('throws provider_unsupported_operation for completeWithTools', async () => {
+  // assert message contains both "copilot" and "completeWithTools"
+});
+```
+
+- [ ] **Step 3: Run tests to confirm red state**
+
+Run:
+
+```bash
+cd tools/evaluator
+npx vitest run __tests__/copilot-client.test.ts
+```
+
+Expected: FAIL because Copilot adapter and explicit errors are not implemented yet.
+
+- [ ] **Step 4: Commit red tests**
+
+```bash
+git add tools/evaluator/__tests__/copilot-client.test.ts
+git commit -S -m "test: lock copilot provider contract"
+```
+
+## Task 4: Implement Copilot Adapter And CLI Wiring
+
+**Files:**
+- Create: `tools/evaluator/src/adapters/llm/copilot-client.ts`
+- Modify: `tools/evaluator/src/adapters/llm-client.ts`
+- Modify: `tools/evaluator/src/cli.ts`
+- Modify: `tools/evaluator/package.json`
+
+- [ ] **Step 1: Add Copilot SDK dependency**
+
+Add dependency:
+
+```json
+"@github/copilot-sdk": "<pin-concrete-version>"
+```
+
+Then install:
+
+```bash
+cd tools/evaluator
+npm install
+```
+
+- [ ] **Step 2: Implement single-turn Copilot session flow**
+
+In `copilot-client.ts`, implement:
+
+```ts
+// pseudo-contract
+complete(prompt, options) =>
+  create session (model, working directory, system prompt replace mode)
+  subscribe events
+  aggregate assistant content + usage events
+  enforce timeout (default 60000ms)
+  return { content, tokensInput, tokensOutput }
+```
+
+Error categories required in thrown messages:
+
+- `provider_unavailable`
+- `provider_timeout`
+- `provider_empty_response`
+
+- [ ] **Step 3: Implement explicit unsupported tool-calling behavior on Copilot**
+
+`completeWithTools(...)` must throw `provider_unsupported_operation` with provider name (`copilot`) in message.
+
+- [ ] **Step 4: Add CLI provider option and provider-aware validation**
+
+Update evaluate command options:
+
+```ts
+.option('--provider <provider>', 'LLM provider: copilot | openai', 'copilot')
+```
+
+Validation rules:
+
+- unsupported provider => fail fast
+- `openai` without `LLM_API_KEY` => fail fast
+- `copilot` path does not require `LLM_API_KEY`
+- `copilot` preflight fails fast with `provider_unavailable` when:
+  - Copilot SDK is not resolvable at runtime
+  - Copilot session initialization fails for selected model
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+cd tools/evaluator
+npx vitest run __tests__/cli-provider.test.ts __tests__/llm-client-factory.test.ts __tests__/copilot-client.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit implementation**
+
+```bash
+git add tools/evaluator/src/adapters/llm/copilot-client.ts tools/evaluator/src/adapters/llm-client.ts tools/evaluator/src/cli.ts tools/evaluator/package.json tools/evaluator/package-lock.json
+git commit -S -m "feat: add copilot sdk provider for evaluator"
+```
+
+## Task 5: Add Command-Level Provider Integration Tests
+
+**Files:**
+- Create: `tools/evaluator/__tests__/evaluate-provider.integration.test.ts`
+
+- [ ] **Step 1: Add evaluate command tests for provider defaults and fail-fast behavior**
+
+Add tests such as:
+
+```ts
+it('fails evaluate when copilot initialization fails and does not fallback to openai', async () => {
+  // assert command exits with provider_unavailable and openai constructor is never called
+});
+
+it('uses openai when --provider openai is provided', async () => {
+  // assert openai path selected and copilot path not used
+});
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run:
+
+```bash
+cd tools/evaluator
+npx vitest run __tests__/evaluate-provider.integration.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit integration test coverage**
+
+```bash
+git add tools/evaluator/__tests__/evaluate-provider.integration.test.ts
+git commit -S -m "test: cover provider selection in evaluate command"
+```
+
+## Task 6: Lock End-to-End Evaluator Behavior Across Runner/Judge
+
+**Files:**
+- Modify: `tools/evaluator/__tests__/runner.test.ts`
+- Modify: `tools/evaluator/__tests__/judge.test.ts`
+- Modify: `tools/evaluator/src/core/runner.ts` (only if required by signatures)
+- Modify: `tools/evaluator/src/core/judge.ts` (only if required by signatures)
+
+- [ ] **Step 1: Add tests proving provider-agnostic core behavior**
+
+Add tests verifying `runner` and `judge` use only `LLMClient` contract and do not branch by provider.
+
+- [ ] **Step 2: Add no-fallback failure-path test**
+
+Add a test where Copilot client throws provider error and assert evaluation fails without reattempting OpenAI.
+
+- [ ] **Step 3: Run scenario tests**
+
+Run:
+
+```bash
+cd tools/evaluator
+npx vitest run __tests__/runner.test.ts __tests__/judge.test.ts
+```
+
+Expected: PASS with explicit failure behavior preserved.
+
+- [ ] **Step 4: Commit behavior locks**
+
+```bash
+git add tools/evaluator/__tests__/runner.test.ts tools/evaluator/__tests__/judge.test.ts
+git commit -S -m "test: enforce provider-agnostic evaluator core"
+```
+
+## Task 7: Full Verification Before Completion
+
+**Files:**
+- Modify: none expected (verification only)
+
+- [ ] **Step 1: Run full evaluator test suite**
+
+```bash
+cd tools/evaluator
+npm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run typecheck and lint**
+
+```bash
+cd tools/evaluator
+npm run typecheck
+npm run lint
+```
+
+Expected: PASS with no new errors.
+
+- [ ] **Step 3: Smoke test evaluate CLI for both providers**
+
+- [ ] **Step 3: Generate deterministic entries file for smoke testing**
+
+```bash
+cd tools/evaluator
+npm run dev -- discover --all --repo-root ../.. --output ./tmp/discovered.json
+```
+
+Expected: `./tmp/discovered.json` exists and contains at least an `entries` array.
+
+- [ ] **Step 4: Smoke test evaluate CLI for both providers**
+
+```bash
+cd tools/evaluator
+npm run dev -- evaluate --entries ./tmp/discovered.json --provider copilot --model gpt-4o --repo-root ../..
+LLM_API_KEY=<value> npm run dev -- evaluate --entries ./tmp/discovered.json --provider openai --model gpt-4o --repo-root ../..
+```
+
+Expected:
+
+- Copilot path starts and uses provider `copilot` by default when omitted.
+- OpenAI path requires `LLM_API_KEY` and runs when provided.
+
+- [ ] **Step 5: Final signed commit for any remaining integration fixes**
+
+```bash
+git add -A
+git commit -S -m "chore: finalize copilot/openai provider integration"
+```
+
+## Relevant Skills During Execution
+
+- `@superpowers:test-driven-development` for red/green discipline task-by-task.
+- `@superpowers:verification-before-completion` before claiming success.
+- `@superpowers:subagent-driven-development` (recommended execution mode).
+- `@superpowers:requesting-code-review` after implementation stabilizes.

--- a/docs/superpowers/specs/2026-04-16-copilot-sdk-evaluator-provider-design.md
+++ b/docs/superpowers/specs/2026-04-16-copilot-sdk-evaluator-provider-design.md
@@ -1,0 +1,223 @@
+# Copilot SDK Provider Design For Evaluator
+
+## Goal
+
+Introduce GitHub Copilot SDK support into `tools/evaluator` while keeping OpenAI support as a coexisting provider.
+
+The evaluator must:
+
+- support both `copilot` and `openai` providers
+- default to `copilot`
+- expose provider choice through CLI flag `--provider`
+- use the selected provider across all evaluators
+- report only input/output tokens
+- raise an explicit error when Copilot initialization or execution fails (no automatic fallback)
+
+## Scope
+
+Primary implementation scope:
+
+- `tools/evaluator/src/cli.ts`
+- `tools/evaluator/src/adapters/llm-client.ts` (or split into provider files)
+- evaluator call sites using `LLMClient` (runner/judge paths)
+- tests in `tools/evaluator/__tests__/**`
+- evaluator package dependencies in `tools/evaluator/package.json`
+
+Out of scope:
+
+- changing benchmark schema beyond existing `input` and `output`
+- adding provider auto-detection or silent fallback behavior
+
+## Constraints
+
+- Provider behavior must be deterministic and explicit.
+- Invalid provider values must fail fast.
+- Copilot failures must fail the run with actionable errors.
+- Existing OpenAI behavior must remain available when `--provider openai` is selected.
+- The public `LLMClient` interface used by evaluators should stay stable or change minimally with clear migration updates.
+
+## Current Baseline
+
+The current evaluator creates one OpenAI-backed client from `createLLMClient({ apiKey, model })` and uses it for all evaluation calls.
+
+Key observations:
+
+- `LLMResponse` already carries `tokensInput` and `tokensOutput`
+- all downstream reporting expects input/output totals
+- CLI currently does not expose provider selection
+
+## Recommended Architecture
+
+Use a provider abstraction with two implementations behind a unified `LLMClient` contract.
+
+### 1. Provider model
+
+Introduce provider type:
+
+- `type LLMProvider = 'copilot' | 'openai'`
+
+Introduce a provider-aware client config:
+
+- `provider: LLMProvider` (defaulted by CLI to `copilot`)
+- `model: string`
+- OpenAI-specific `apiKey` and `baseURL` remain required only for `openai`
+- Copilot-specific options are explicit:
+  - `workDir: string` (repository root)
+  - `timeoutMs: number` (default `60_000`)
+  - `systemPromptMode: 'replace'` for parity with .NET `LlmSession`
+
+### 2. Factory
+
+Replace the monolithic OpenAI construction path with a provider factory:
+
+- `createLLMClient(config)` switches on `config.provider`
+- returns `CopilotLLMClient` or `OpenAiLLMClient`
+- throws for unknown provider
+
+### 3. Copilot implementation
+
+Implement single-turn request flow analogous to the .NET `LlmSession` pattern:
+
+- create session with requested model/system prompt/working directory
+- stream events until idle
+- accumulate assistant content
+- accumulate usage events by summing all usage events emitted before idle
+- map token usage to evaluator schema:
+  - `tokensInput = inputTokens`
+  - `tokensOutput = outputTokens`
+- ignore cache token fields for persisted metrics
+- enforce timeout (default `60_000ms`) and propagate explicit error messages
+
+No fallback path:
+
+- if session creation fails, throw
+- if no assistant content returned, throw
+- if timeout occurs, throw
+
+### 4. OpenAI implementation
+
+Move existing OpenAI logic into a dedicated implementation preserving behavior.
+
+- support `complete`
+- preserve existing `completeWithTools` behavior
+- keep existing token accounting
+
+Provider capability boundary:
+
+- `completeWithTools` remains OpenAI-capable behavior.
+- Copilot provider returns an explicit unsupported error when tool-calling is requested.
+- Error text must include provider name and operation (`completeWithTools`).
+
+### 5. CLI and wiring
+
+Add CLI option to `evaluate` command:
+
+- `--provider <provider>`
+- allowed values: `copilot`, `openai`
+- default: `copilot`
+
+Pass selected provider through to client factory.
+
+Validation behavior:
+
+- fail fast with clear message for unsupported value
+- for `openai`, require `LLM_API_KEY`
+- for `copilot`, validate runtime prerequisites explicitly and fail fast when missing:
+  - Copilot SDK package is resolvable at runtime
+  - session initialization succeeds for the selected model
+
+### 6. Compatibility for evaluators
+
+All evaluator flows continue to consume `LLMClient` only.
+
+No evaluator-specific branching by provider should appear in business logic; provider branching remains inside adapter/factory layer.
+
+## File-Level Change Plan
+
+- `tools/evaluator/src/adapters/llm-client.ts`
+  - add provider types and factory dispatch
+  - split provider implementations in-place or into:
+    - `tools/evaluator/src/adapters/llm/openai-client.ts`
+    - `tools/evaluator/src/adapters/llm/copilot-client.ts`
+- `tools/evaluator/src/cli.ts`
+  - add `--provider` option with default `copilot`
+  - wire provider into `createLLMClient`
+  - gate env validation by provider
+- `tools/evaluator/src/core/*` (only if typing changes propagate)
+  - minimal adaptation if required
+- `tools/evaluator/package.json`
+  - add `@github/copilot-sdk` dependency (pin to a concrete semver range in implementation PR)
+- tests under `tools/evaluator/__tests__`
+  - add/adjust unit tests for provider selection and error behavior
+
+## Error Handling Contract
+
+Expected explicit failures:
+
+- unknown provider
+- Copilot SDK unavailable or session initialization failure
+- Copilot timeout
+- Copilot empty response
+- OpenAI selected without required API key
+
+Error messages must name the provider and remediation hint where possible.
+
+Stable error categories for assertions:
+
+- `provider_invalid`
+- `provider_unavailable`
+- `provider_timeout`
+- `provider_empty_response`
+- `provider_unsupported_operation`
+
+## Testing Strategy
+
+### Unit tests
+
+- provider parsing and default value behavior in CLI
+- factory returns correct implementation for `copilot` and `openai`
+- factory throws on unsupported provider
+- Copilot adapter maps usage to input/output correctly
+- Copilot adapter surfaces timeout and session errors
+
+### Integration-level tests (mocked SDK boundaries)
+
+- `evaluate --provider copilot` runs through full evaluation path
+- `evaluate --provider openai` preserves existing path
+- no hidden fallback from copilot to openai on error
+
+### Requirement-to-test traceability
+
+| Requirement | Acceptance Criteria | Minimum tests |
+| --- | --- | --- |
+| Coexistence of providers | #1, #2 | factory selection tests for `copilot` and `openai` |
+| `--provider` flag with default `copilot` | #1 | CLI parsing test for omitted flag and explicit values |
+| Applies to all evaluator flows | #6, #7 | call-site propagation tests for all `LLMClient` consumers (`runner` and `judge`) |
+| Input/output token reporting only | #3 | usage mapping tests for OpenAI and Copilot adapters |
+| Copilot failure must error, no fallback | #4 | failure-path integration tests asserting no provider switch |
+
+## Acceptance Criteria
+
+1. Running `evaluate` without `--provider` uses `copilot`.
+2. Running with `--provider openai` continues to work with current OpenAI behavior.
+3. All evaluator runs record only input/output tokens regardless of provider.
+4. Copilot failure causes evaluation failure with explicit error; no provider fallback occurs.
+5. Existing reporters and benchmark outputs continue to work without schema changes.
+6. Test suite includes provider selection and failure-mode coverage.
+7. Provider selection is propagated to all evaluator call sites that consume `LLMClient` (`runner` and `judge`) with explicit tests.
+
+## Risks and Mitigations
+
+- Risk: Copilot SDK event model mismatch with current assumptions.
+  - Mitigation: isolate in dedicated adapter and test with mocked event streams.
+- Risk: provider-specific env requirements create UX confusion.
+  - Mitigation: provider-aware validation and clear CLI help text.
+- Risk: regression in tool-calling flow (`completeWithTools`).
+  - Mitigation: keep OpenAI implementation untouched except extraction/refactor.
+
+## Rollout Notes
+
+- Merge provider abstraction and OpenAI extraction first.
+- Add Copilot provider behind same interface next.
+- Ship with default provider = `copilot` in the first merged release.
+- Keep `--provider openai` documented as compatibility mode.

--- a/tools/evaluator/__tests__/benchmark-summary.test.ts
+++ b/tools/evaluator/__tests__/benchmark-summary.test.ts
@@ -43,6 +43,7 @@ function makeFreshResult(id: string, source: EvaluationResult['source'] = 'pr'):
     overallScore: 1,
     passRate: 1,
     passed: true,
+    skipped: false,
     totalTokensInput: 200,
     totalTokensOutput: 80,
     source,

--- a/tools/evaluator/__tests__/cli-provider.test.ts
+++ b/tools/evaluator/__tests__/cli-provider.test.ts
@@ -133,10 +133,10 @@ describe('evaluate command provider behavior', () => {
     try {
       await runEvaluateCommand([]);
 
+      expect(mockedCreateLLMClient).toHaveBeenCalledTimes(1);
       expect(mockedCreateLLMClient).toHaveBeenCalledWith(
         expect.objectContaining({
           provider: 'copilot',
-          model: 'gpt-4o',
         }),
       );
     } finally {
@@ -163,7 +163,6 @@ describe('evaluate command provider behavior', () => {
 
   it('fails fast for unsupported provider values', async () => {
     const restoreApiKey = withEnv('LLM_API_KEY', 'openai-key');
-    const loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => {
       throw new ProcessExitError(code);
     }) as typeof process.exit);
@@ -173,12 +172,10 @@ describe('evaluate command provider behavior', () => {
         code: 1,
       });
 
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
-        expect.stringMatching(/unsupported provider/i),
-      );
+      expect(mockedCreateLLMClient).not.toHaveBeenCalled();
+      expect(mockedRunEvaluation).not.toHaveBeenCalled();
     } finally {
       restoreApiKey();
-      loggerErrorSpy.mockRestore();
       exitSpy.mockRestore();
     }
   });
@@ -217,18 +214,4 @@ describe('evaluate command provider behavior', () => {
     }
   });
 
-  it('dispatches omitted --provider evaluate path to copilot factory', async () => {
-    const restoreApiKey = withEnv('LLM_API_KEY', 'openai-key');
-
-    try {
-      await runEvaluateCommand([]);
-
-      expect(mockedCreateLLMClient).toHaveBeenCalledTimes(1);
-      expect(mockedCreateLLMClient.mock.calls[0]?.[0]).toMatchObject({
-        provider: 'copilot',
-      });
-    } finally {
-      restoreApiKey();
-    }
-  });
 });

--- a/tools/evaluator/__tests__/cli-provider.test.ts
+++ b/tools/evaluator/__tests__/cli-provider.test.ts
@@ -223,9 +223,9 @@ describe('evaluate command provider behavior', () => {
     }
   });
 
-  it('passes GITHUB_TOKEN to the LLM client when available', async () => {
+  it('passes COPILOT_GITHUB_TOKEN to the LLM client when available', async () => {
     const restoreApiKey = withEnv('LLM_API_KEY', undefined);
-    const restoreGithubToken = withEnv('GITHUB_TOKEN', 'gh-test-token');
+    const restoreGithubToken = withEnv('COPILOT_GITHUB_TOKEN', 'gh-test-token');
 
     try {
       await runEvaluateCommand(['--provider', 'copilot']);

--- a/tools/evaluator/__tests__/cli-provider.test.ts
+++ b/tools/evaluator/__tests__/cli-provider.test.ts
@@ -163,6 +163,11 @@ describe('evaluate command provider behavior', () => {
 
   it('fails fast for unsupported provider values', async () => {
     const restoreApiKey = withEnv('LLM_API_KEY', 'openai-key');
+    const stderrChunks: string[] = [];
+    const stderrWriteSpy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: unknown) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write);
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => {
       throw new ProcessExitError(code);
     }) as typeof process.exit);
@@ -174,8 +179,12 @@ describe('evaluate command provider behavior', () => {
 
       expect(mockedCreateLLMClient).not.toHaveBeenCalled();
       expect(mockedRunEvaluation).not.toHaveBeenCalled();
+      const stderrOutput = stderrChunks.join('');
+      expect(stderrOutput).toContain('unsupported-provider');
+      expect(stderrOutput).toContain('provider');
     } finally {
       restoreApiKey();
+      stderrWriteSpy.mockRestore();
       exitSpy.mockRestore();
     }
   });

--- a/tools/evaluator/__tests__/cli-provider.test.ts
+++ b/tools/evaluator/__tests__/cli-provider.test.ts
@@ -129,6 +129,7 @@ afterEach(() => {
 describe('evaluate command provider behavior', () => {
   it('uses copilot provider when --provider is omitted', async () => {
     const restoreApiKey = withEnv('LLM_API_KEY', 'openai-key');
+    const restoreToken = withEnv('COPILOT_GITHUB_TOKEN', 'gh-test-token');
 
     try {
       await runEvaluateCommand([]);
@@ -141,6 +142,7 @@ describe('evaluate command provider behavior', () => {
       );
     } finally {
       restoreApiKey();
+      restoreToken();
     }
   });
 
@@ -208,6 +210,7 @@ describe('evaluate command provider behavior', () => {
 
   it('does not require LLM_API_KEY when provider is copilot', async () => {
     const restoreApiKey = withEnv('LLM_API_KEY', undefined);
+    const restoreToken = withEnv('COPILOT_GITHUB_TOKEN', 'gh-test-token');
 
     try {
       await runEvaluateCommand(['--provider', 'copilot']);
@@ -220,6 +223,24 @@ describe('evaluate command provider behavior', () => {
       );
     } finally {
       restoreApiKey();
+      restoreToken();
+    }
+  });
+
+  it('requires COPILOT_GITHUB_TOKEN when provider is copilot', async () => {
+    const restoreToken = withEnv('COPILOT_GITHUB_TOKEN', undefined);
+    const loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => {
+      throw new ProcessExitError(code);
+    }) as typeof process.exit);
+
+    try {
+      await expect(runEvaluateCommand(['--provider', 'copilot'])).rejects.toMatchObject({ code: 1 });
+      expect(loggerErrorSpy).toHaveBeenCalledWith('COPILOT_GITHUB_TOKEN environment variable is required for copilot provider');
+    } finally {
+      restoreToken();
+      loggerErrorSpy.mockRestore();
+      exitSpy.mockRestore();
     }
   });
 

--- a/tools/evaluator/__tests__/cli-provider.test.ts
+++ b/tools/evaluator/__tests__/cli-provider.test.ts
@@ -223,4 +223,23 @@ describe('evaluate command provider behavior', () => {
     }
   });
 
+  it('passes GITHUB_TOKEN to the LLM client when available', async () => {
+    const restoreApiKey = withEnv('LLM_API_KEY', undefined);
+    const restoreGithubToken = withEnv('GITHUB_TOKEN', 'gh-test-token');
+
+    try {
+      await runEvaluateCommand(['--provider', 'copilot']);
+
+      expect(mockedCreateLLMClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'copilot',
+          githubToken: 'gh-test-token',
+        }),
+      );
+    } finally {
+      restoreApiKey();
+      restoreGithubToken();
+    }
+  });
+
 });

--- a/tools/evaluator/__tests__/cli-provider.test.ts
+++ b/tools/evaluator/__tests__/cli-provider.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { DiscoveredEntry, EvaluationResult } from '../src/core/types.js';
+
+vi.mock('../src/adapters/llm-client.js', () => ({
+  createLLMClient: vi.fn(() => ({
+    complete: vi.fn(),
+    completeWithTools: vi.fn(),
+  })),
+}));
+
+vi.mock('../src/adapters/file-reader.js', () => ({
+  createFileReader: vi.fn(() => ({
+    exists: vi.fn().mockReturnValue(true),
+    readFile: vi.fn(),
+    readFileRelative: vi.fn(),
+  })),
+}));
+
+vi.mock('../src/core/runner.js', () => ({
+  runEvaluation: vi.fn(async (entry: DiscoveredEntry): Promise<EvaluationResult> => ({
+    id: entry.id,
+    kind: entry.kind,
+    name: entry.id.split(':')[1] ?? entry.id,
+    assetPath: entry.assetPath,
+    model: 'gpt-4o',
+    startedAt: '2026-04-16T00:00:00.000Z',
+    finishedAt: '2026-04-16T00:00:01.000Z',
+    scenarios: [],
+    overallScore: 1,
+    passRate: 1,
+    passed: true,
+    skipped: false,
+    totalTokensInput: 0,
+    totalTokensOutput: 0,
+    source: 'manual',
+    commitSha: 'test-sha',
+  })),
+}));
+
+import { createLLMClient } from '../src/adapters/llm-client.js';
+import { runEvaluation } from '../src/core/runner.js';
+import { logger } from '../src/utils/logger.js';
+import { buildCLI } from '../src/cli.js';
+
+const mockedCreateLLMClient = vi.mocked(createLLMClient);
+const mockedRunEvaluation = vi.mocked(runEvaluation);
+
+class ProcessExitError extends Error {
+  readonly code: number | string | null | undefined;
+
+  constructor(code: number | string | null | undefined) {
+    super(`process.exit:${String(code)}`);
+    this.code = code;
+  }
+}
+
+function writeDiscoveredEntriesFile(rootDir: string): string {
+  const entriesPath = join(rootDir, 'discovered.json');
+  const entries: { entries: DiscoveredEntry[] } = {
+    entries: [
+      {
+        id: 'skill:provider-test',
+        kind: 'skill',
+        assetPath: 'skills/provider-test',
+        testPath: 'tests/skills/provider-test',
+        changedFiles: ['skills/provider-test/SKILL.md'],
+      },
+    ],
+  };
+
+  writeFileSync(entriesPath, JSON.stringify(entries, null, 2), 'utf-8');
+  return entriesPath;
+}
+
+async function runEvaluateCommand(args: string[]): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), 'evaluator-cli-provider-'));
+  const outputDir = join(root, 'results');
+  mkdirSync(outputDir, { recursive: true });
+  const entriesPath = writeDiscoveredEntriesFile(root);
+
+  try {
+    await buildCLI().parseAsync([
+      'node',
+      'evaluator',
+      'evaluate',
+      '--entries',
+      entriesPath,
+      '--output',
+      outputDir,
+      '--repo-root',
+      root,
+      ...args,
+    ]);
+
+    const summaryPath = join(outputDir, 'results-summary.json');
+    expect(readFileSync(summaryPath, 'utf-8')).toContain('provider-test');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function withEnv(key: string, value: string | undefined): () => void {
+  const previous = process.env[key];
+
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+
+  return () => {
+    if (previous === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = previous;
+    }
+  };
+}
+
+afterEach(() => {
+  mockedCreateLLMClient.mockClear();
+  mockedRunEvaluation.mockClear();
+  vi.restoreAllMocks();
+});
+
+describe('evaluate command provider behavior', () => {
+  it('uses copilot provider when --provider is omitted', async () => {
+    const restoreApiKey = withEnv('LLM_API_KEY', 'openai-key');
+
+    try {
+      await runEvaluateCommand([]);
+
+      expect(mockedCreateLLMClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'copilot',
+          model: 'gpt-4o',
+        }),
+      );
+    } finally {
+      restoreApiKey();
+    }
+  });
+
+  it('accepts --provider openai', async () => {
+    const restoreApiKey = withEnv('LLM_API_KEY', 'openai-key');
+
+    try {
+      await runEvaluateCommand(['--provider', 'openai']);
+
+      expect(mockedCreateLLMClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'openai',
+          apiKey: 'openai-key',
+        }),
+      );
+    } finally {
+      restoreApiKey();
+    }
+  });
+
+  it('fails fast for unsupported provider values', async () => {
+    const restoreApiKey = withEnv('LLM_API_KEY', 'openai-key');
+    const loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => {
+      throw new ProcessExitError(code);
+    }) as typeof process.exit);
+
+    try {
+      await expect(runEvaluateCommand(['--provider', 'unsupported-provider'])).rejects.toMatchObject({
+        code: 1,
+      });
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/unsupported provider/i),
+      );
+    } finally {
+      restoreApiKey();
+      loggerErrorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('requires LLM_API_KEY when provider is openai', async () => {
+    const restoreApiKey = withEnv('LLM_API_KEY', undefined);
+    const loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => {
+      throw new ProcessExitError(code);
+    }) as typeof process.exit);
+
+    try {
+      await expect(runEvaluateCommand(['--provider', 'openai'])).rejects.toMatchObject({ code: 1 });
+      expect(loggerErrorSpy).toHaveBeenCalledWith('LLM_API_KEY environment variable is required');
+    } finally {
+      restoreApiKey();
+      loggerErrorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('does not require LLM_API_KEY when provider is copilot', async () => {
+    const restoreApiKey = withEnv('LLM_API_KEY', undefined);
+
+    try {
+      await runEvaluateCommand(['--provider', 'copilot']);
+
+      expect(mockedRunEvaluation).toHaveBeenCalledTimes(1);
+      expect(mockedCreateLLMClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'copilot',
+        }),
+      );
+    } finally {
+      restoreApiKey();
+    }
+  });
+
+  it('dispatches omitted --provider evaluate path to copilot factory', async () => {
+    const restoreApiKey = withEnv('LLM_API_KEY', 'openai-key');
+
+    try {
+      await runEvaluateCommand([]);
+
+      expect(mockedCreateLLMClient).toHaveBeenCalledTimes(1);
+      expect(mockedCreateLLMClient.mock.calls[0]?.[0]).toMatchObject({
+        provider: 'copilot',
+      });
+    } finally {
+      restoreApiKey();
+    }
+  });
+});

--- a/tools/evaluator/__tests__/copilot-client.test.ts
+++ b/tools/evaluator/__tests__/copilot-client.test.ts
@@ -124,10 +124,42 @@ describe('createCopilotClient contract', () => {
     await expect(client.complete('Return empty content')).rejects.toThrow(/provider_empty_response/);
   });
 
-  it('throws provider_unsupported_operation for completeWithTools with copilot context', async () => {
+  it('completeWithTools falls back to complete with embedded file contents', async () => {
     const client = await createClientFromMock({
-      content: 'noop',
-      usage: { inputTokens: 1, outputTokens: 1 },
+      content: 'Answer using file context.',
+      usage: { inputTokens: 200, outputTokens: 50 },
+    });
+    const tools: ToolDefinition[] = [
+      {
+        name: 'read_file',
+        description: `Read a documentation file from the skill/plugin. Available files:\nREADME.md\nSKILL.md`,
+        parameters: {
+          type: 'object',
+          properties: {
+            path: { type: 'string', description: 'File path' },
+          },
+          required: ['path'],
+        },
+      },
+    ];
+    const handlers = new Map<string, ToolHandler>();
+    handlers.set('read_file', async (args: Record<string, unknown>) => {
+      const path = String(args['path'] ?? '');
+      if (path === 'README.md') return '# Project README';
+      if (path === 'SKILL.md') return '# Skill Definition';
+      return `File not found: ${path}`;
+    });
+
+    const result = await client.completeWithTools('Use tools', tools, handlers);
+    expect(result.content).toBe('Answer using file context.');
+    expect(result.tokensInput).toBe(200);
+    expect(result.tokensOutput).toBe(50);
+  });
+
+  it('completeWithTools works with no read_file tool defined', async () => {
+    const client = await createClientFromMock({
+      content: 'No tools needed.',
+      usage: { inputTokens: 10, outputTokens: 5 },
     });
     const tools: ToolDefinition[] = [
       {
@@ -138,14 +170,7 @@ describe('createCopilotClient contract', () => {
     ];
     const handlers = new Map<string, ToolHandler>();
 
-    await expect(
-      client.completeWithTools('Use tools', tools, handlers),
-    ).rejects.toThrow(/provider_unsupported_operation/);
-    await expect(
-      client.completeWithTools('Use tools', tools, handlers),
-    ).rejects.toThrow(/copilot/i);
-    await expect(
-      client.completeWithTools('Use tools', tools, handlers),
-    ).rejects.toThrow(/completeWithTools/);
+    const result = await client.completeWithTools('Use tools', tools, handlers);
+    expect(result.content).toBe('No tools needed.');
   });
 });

--- a/tools/evaluator/__tests__/copilot-client.test.ts
+++ b/tools/evaluator/__tests__/copilot-client.test.ts
@@ -9,40 +9,59 @@ import type {
 const COPILOT_ADAPTER_MODULE = '../src/adapters/llm/copilot-client.js';
 const COPILOT_SDK_MODULE = '@github/copilot-sdk';
 
-type CopilotCompletion = {
-  assistant?: {
-    content?: string;
-  };
-  usage?: {
-    inputTokens?: number;
-    outputTokens?: number;
-    cacheCreationInputTokens?: number;
-    cacheReadInputTokens?: number;
-    cacheWriteInputTokens?: number;
-  };
+type SDKUsageData = {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+  cacheWriteInputTokens?: number;
 };
 
-type CopilotSession = {
-  complete: (prompt: { prompt: string; model: string }) => Promise<CopilotCompletion>;
+type MockSessionOptions = {
+  content?: string;
+  usage?: SDKUsageData;
+  error?: Error;
 };
-
-type CreateCopilotSession = (options: { model: string; workDir?: string; timeoutMs?: number }) => CopilotSession;
 
 async function loadCopilotClientFactory(): Promise<(config: LLMClientConfig) => LLMClient> {
   const module = await import(COPILOT_ADAPTER_MODULE);
   return (module as { createCopilotClient: (config: LLMClientConfig) => LLMClient }).createCopilotClient;
 }
 
-function mockCopilotSdkSession(factory: CreateCopilotSession): void {
+function mockCopilotSdk(opts: MockSessionOptions): void {
   vi.doMock(COPILOT_SDK_MODULE, () => ({
-    createCopilotSession: vi.fn(factory),
+    CopilotClient: vi.fn().mockImplementation(() => ({
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue([]),
+      createSession: vi.fn().mockImplementation(async () => {
+        const usageHandlers: Array<(event: { data: unknown }) => void> = [];
+        return {
+          sendAndWait: vi.fn(async () => {
+            if (opts.error) throw opts.error;
+            // Emit usage event before returning the assistant message
+            for (const h of usageHandlers) {
+              h({ data: opts.usage ?? {} });
+            }
+            const content = opts.content ?? '';
+            return { type: 'assistant.message', data: { content } };
+          }),
+          on: vi.fn((eventType: string, handler: (event: { data: unknown }) => void) => {
+            if (eventType === 'assistant.usage') {
+              usageHandlers.push(handler);
+            }
+            return () => {};
+          }),
+          disconnect: vi.fn().mockResolvedValue(undefined),
+        };
+      }),
+    })),
+    approveAll: vi.fn(() => ({ kind: 'approved' })),
   }));
 }
 
-async function createClientFromSession(session: CopilotSession): Promise<LLMClient> {
-  mockCopilotSdkSession(() => session);
+async function createClientFromMock(opts: MockSessionOptions): Promise<LLMClient> {
+  mockCopilotSdk(opts);
   const createCopilotClient = await loadCopilotClientFactory();
-
   return createCopilotClient({
     provider: 'copilot',
     model: 'gpt-4.1',
@@ -58,14 +77,9 @@ describe('createCopilotClient contract', () => {
   });
 
   it('maps copilot usage input/output to tokensInput/tokensOutput', async () => {
-    const client = await createClientFromSession({
-      complete: vi.fn(async () => ({
-        assistant: { content: 'Answer from copilot.' },
-        usage: {
-          inputTokens: 123,
-          outputTokens: 45,
-        },
-      })),
+    const client = await createClientFromMock({
+      content: 'Answer from copilot.',
+      usage: { inputTokens: 123, outputTokens: 45 },
     });
 
     await expect(client.complete('Say hello')).resolves.toEqual({
@@ -76,17 +90,15 @@ describe('createCopilotClient contract', () => {
   });
 
   it('ignores cache token fields and persists only input/output totals', async () => {
-    const client = await createClientFromSession({
-      complete: vi.fn(async () => ({
-        assistant: { content: 'Cache-aware response.' },
-        usage: {
-          inputTokens: 200,
-          outputTokens: 30,
-          cacheCreationInputTokens: 999,
-          cacheReadInputTokens: 555,
-          cacheWriteInputTokens: 444,
-        },
-      })),
+    const client = await createClientFromMock({
+      content: 'Cache-aware response.',
+      usage: {
+        inputTokens: 200,
+        outputTokens: 30,
+        cacheCreationInputTokens: 999,
+        cacheReadInputTokens: 555,
+        cacheWriteInputTokens: 444,
+      },
     });
 
     const result = await client.complete('Summarize cache accounting');
@@ -96,38 +108,26 @@ describe('createCopilotClient contract', () => {
   });
 
   it('throws provider_timeout when session idle timeout occurs', async () => {
-    const client = await createClientFromSession({
-      complete: vi.fn(async () => {
-        throw new Error('Session idle timeout exceeded while awaiting assistant response');
-      }),
+    const client = await createClientFromMock({
+      error: new Error('Session idle timeout exceeded while awaiting assistant response'),
     });
 
     await expect(client.complete('Will this timeout?')).rejects.toThrow(/provider_timeout/);
   });
 
   it('throws provider_empty_response when assistant content is empty', async () => {
-    const client = await createClientFromSession({
-      complete: vi.fn(async () => ({
-        assistant: { content: '' },
-        usage: {
-          inputTokens: 70,
-          outputTokens: 12,
-        },
-      })),
+    const client = await createClientFromMock({
+      content: '',
+      usage: { inputTokens: 70, outputTokens: 12 },
     });
 
     await expect(client.complete('Return empty content')).rejects.toThrow(/provider_empty_response/);
   });
 
   it('throws provider_unsupported_operation for completeWithTools with copilot context', async () => {
-    const client = await createClientFromSession({
-      complete: vi.fn(async () => ({
-        assistant: { content: 'noop' },
-        usage: {
-          inputTokens: 1,
-          outputTokens: 1,
-        },
-      })),
+    const client = await createClientFromMock({
+      content: 'noop',
+      usage: { inputTokens: 1, outputTokens: 1 },
     });
     const tools: ToolDefinition[] = [
       {

--- a/tools/evaluator/__tests__/copilot-client.test.ts
+++ b/tools/evaluator/__tests__/copilot-client.test.ts
@@ -223,4 +223,30 @@ describe('createCopilotClient contract', () => {
       description: 'Dummy tool for contract test.',
     }));
   });
+
+  it('throws provider_unavailable when githubToken is an empty string', async () => {
+    mockCopilotSdk({ content: 'Should not reach here.', usage: { inputTokens: 1, outputTokens: 1 } });
+    const createCopilotClient = await loadCopilotClientFactory();
+    expect(() =>
+      createCopilotClient({
+        provider: 'copilot',
+        model: 'gpt-4.1',
+        workDir: '/tmp/evaluator',
+        githubToken: '',
+      }),
+    ).toThrow(/provider_unavailable.*empty/);
+  });
+
+  it('throws provider_unavailable when githubToken is whitespace-only', async () => {
+    mockCopilotSdk({ content: 'Should not reach here.', usage: { inputTokens: 1, outputTokens: 1 } });
+    const createCopilotClient = await loadCopilotClientFactory();
+    expect(() =>
+      createCopilotClient({
+        provider: 'copilot',
+        model: 'gpt-4.1',
+        workDir: '/tmp/evaluator',
+        githubToken: '   ',
+      }),
+    ).toThrow(/provider_unavailable.*empty/);
+  });
 });

--- a/tools/evaluator/__tests__/copilot-client.test.ts
+++ b/tools/evaluator/__tests__/copilot-client.test.ts
@@ -34,13 +34,9 @@ async function loadCopilotClientFactory(): Promise<(config: LLMClientConfig) => 
 }
 
 function mockCopilotSdkSession(factory: CreateCopilotSession): void {
-  vi.doMock(
-    COPILOT_SDK_MODULE,
-    () => ({
-      createCopilotSession: vi.fn(factory),
-    }),
-    { virtual: true },
-  );
+  vi.doMock(COPILOT_SDK_MODULE, () => ({
+    createCopilotSession: vi.fn(factory),
+  }));
 }
 
 async function createClientFromSession(session: CopilotSession): Promise<LLMClient> {

--- a/tools/evaluator/__tests__/copilot-client.test.ts
+++ b/tools/evaluator/__tests__/copilot-client.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  LLMClient,
+  LLMClientConfig,
+  ToolDefinition,
+  ToolHandler,
+} from '../src/adapters/llm-client.js';
+
+const COPILOT_ADAPTER_MODULE = '../src/adapters/llm/copilot-client.js';
+const COPILOT_SDK_MODULE = '@github/copilot-sdk';
+
+type CopilotCompletion = {
+  assistant?: {
+    content?: string;
+  };
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheCreationInputTokens?: number;
+    cacheReadInputTokens?: number;
+    cacheWriteInputTokens?: number;
+  };
+};
+
+type CopilotSession = {
+  complete: (prompt: { prompt: string; model: string }) => Promise<CopilotCompletion>;
+};
+
+type CreateCopilotSession = (options: { model: string; workDir?: string; timeoutMs?: number }) => CopilotSession;
+
+async function loadCopilotClientFactory(): Promise<(config: LLMClientConfig) => LLMClient> {
+  const module = await import(COPILOT_ADAPTER_MODULE);
+  return (module as { createCopilotClient: (config: LLMClientConfig) => LLMClient }).createCopilotClient;
+}
+
+function mockCopilotSdkSession(factory: CreateCopilotSession): void {
+  vi.doMock(
+    COPILOT_SDK_MODULE,
+    () => ({
+      createCopilotSession: vi.fn(factory),
+    }),
+    { virtual: true },
+  );
+}
+
+async function createClientFromSession(session: CopilotSession): Promise<LLMClient> {
+  mockCopilotSdkSession(() => session);
+  const createCopilotClient = await loadCopilotClientFactory();
+
+  return createCopilotClient({
+    provider: 'copilot',
+    model: 'gpt-4.1',
+    workDir: '/tmp/evaluator',
+    timeoutMs: 1200,
+  });
+}
+
+describe('createCopilotClient contract', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('maps copilot usage input/output to tokensInput/tokensOutput', async () => {
+    const client = await createClientFromSession({
+      complete: vi.fn(async () => ({
+        assistant: { content: 'Answer from copilot.' },
+        usage: {
+          inputTokens: 123,
+          outputTokens: 45,
+        },
+      })),
+    });
+
+    await expect(client.complete('Say hello')).resolves.toEqual({
+      content: 'Answer from copilot.',
+      tokensInput: 123,
+      tokensOutput: 45,
+    });
+  });
+
+  it('ignores cache token fields and persists only input/output totals', async () => {
+    const client = await createClientFromSession({
+      complete: vi.fn(async () => ({
+        assistant: { content: 'Cache-aware response.' },
+        usage: {
+          inputTokens: 200,
+          outputTokens: 30,
+          cacheCreationInputTokens: 999,
+          cacheReadInputTokens: 555,
+          cacheWriteInputTokens: 444,
+        },
+      })),
+    });
+
+    const result = await client.complete('Summarize cache accounting');
+
+    expect(result.tokensInput).toBe(200);
+    expect(result.tokensOutput).toBe(30);
+  });
+
+  it('throws provider_timeout when session idle timeout occurs', async () => {
+    const client = await createClientFromSession({
+      complete: vi.fn(async () => {
+        throw new Error('Session idle timeout exceeded while awaiting assistant response');
+      }),
+    });
+
+    await expect(client.complete('Will this timeout?')).rejects.toThrow(/provider_timeout/);
+  });
+
+  it('throws provider_empty_response when assistant content is empty', async () => {
+    const client = await createClientFromSession({
+      complete: vi.fn(async () => ({
+        assistant: { content: '' },
+        usage: {
+          inputTokens: 70,
+          outputTokens: 12,
+        },
+      })),
+    });
+
+    await expect(client.complete('Return empty content')).rejects.toThrow(/provider_empty_response/);
+  });
+
+  it('throws provider_unsupported_operation for completeWithTools with copilot context', async () => {
+    const client = await createClientFromSession({
+      complete: vi.fn(async () => ({
+        assistant: { content: 'noop' },
+        usage: {
+          inputTokens: 1,
+          outputTokens: 1,
+        },
+      })),
+    });
+    const tools: ToolDefinition[] = [
+      {
+        name: 'dummy_tool',
+        description: 'Dummy tool for contract test.',
+        parameters: {},
+      },
+    ];
+    const handlers = new Map<string, ToolHandler>();
+
+    await expect(
+      client.completeWithTools('Use tools', tools, handlers),
+    ).rejects.toThrow(/provider_unsupported_operation/);
+    await expect(
+      client.completeWithTools('Use tools', tools, handlers),
+    ).rejects.toThrow(/copilot/i);
+    await expect(
+      client.completeWithTools('Use tools', tools, handlers),
+    ).rejects.toThrow(/completeWithTools/);
+  });
+});

--- a/tools/evaluator/__tests__/copilot-client.test.ts
+++ b/tools/evaluator/__tests__/copilot-client.test.ts
@@ -89,6 +89,28 @@ describe('createCopilotClient contract', () => {
     });
   });
 
+  it('maps gpt-4o model to gpt-4.1 for the Copilot SDK', async () => {
+    mockCopilotSdk({ content: 'Mapped model response.', usage: { inputTokens: 10, outputTokens: 5 } });
+    const createCopilotClient = await loadCopilotClientFactory();
+    const client = createCopilotClient({
+      provider: 'copilot',
+      model: 'gpt-4o',
+      workDir: '/tmp/evaluator',
+    });
+
+    await client.complete('Hello');
+
+    // Verify the Copilot SDK was called — the session was created successfully
+    // (if gpt-4o were passed to the SDK, it would reject it)
+    const sdk = await import(COPILOT_SDK_MODULE) as { CopilotClient: ReturnType<typeof vi.fn> };
+    const mockClientInstance = sdk.CopilotClient.mock.results[0]?.value as {
+      createSession: ReturnType<typeof vi.fn>;
+    };
+    expect(mockClientInstance.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'gpt-4.1' }),
+    );
+  });
+
   it('ignores cache token fields and persists only input/output totals', async () => {
     const client = await createClientFromMock({
       content: 'Cache-aware response.',

--- a/tools/evaluator/__tests__/copilot-client.test.ts
+++ b/tools/evaluator/__tests__/copilot-client.test.ts
@@ -56,6 +56,10 @@ function mockCopilotSdk(opts: MockSessionOptions): void {
       }),
     })),
     approveAll: vi.fn(() => ({ kind: 'approved' })),
+    defineTool: vi.fn((name: string, config: Record<string, unknown>) => ({
+      name,
+      ...config,
+    })),
   }));
 }
 
@@ -144,7 +148,7 @@ describe('createCopilotClient contract', () => {
     await expect(client.complete('Return empty content')).rejects.toThrow(/provider_empty_response/);
   });
 
-  it('completeWithTools falls back to complete with embedded file contents', async () => {
+  it('completeWithTools registers tools natively on the SDK session', async () => {
     const client = await createClientFromMock({
       content: 'Answer using file context.',
       usage: { inputTokens: 200, outputTokens: 50 },
@@ -174,9 +178,29 @@ describe('createCopilotClient contract', () => {
     expect(result.content).toBe('Answer using file context.');
     expect(result.tokensInput).toBe(200);
     expect(result.tokensOutput).toBe(50);
+
+    // Verify defineTool was called with our tool definition
+    const sdk = await import(COPILOT_SDK_MODULE) as { defineTool: ReturnType<typeof vi.fn> };
+    expect(sdk.defineTool).toHaveBeenCalledWith('read_file', expect.objectContaining({
+      description: expect.stringContaining('Available files'),
+      skipPermission: true,
+    }));
+
+    // Verify tools were passed to createSession
+    const sdkClient = (await import(COPILOT_SDK_MODULE) as { CopilotClient: ReturnType<typeof vi.fn> }).CopilotClient;
+    const mockClientInstance = sdkClient.mock.results[0]?.value as {
+      createSession: ReturnType<typeof vi.fn>;
+    };
+    expect(mockClientInstance.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: expect.arrayContaining([
+          expect.objectContaining({ name: 'read_file' }),
+        ]),
+      }),
+    );
   });
 
-  it('completeWithTools works with no read_file tool defined', async () => {
+  it('completeWithTools passes tools even when no handler is registered', async () => {
     const client = await createClientFromMock({
       content: 'No tools needed.',
       usage: { inputTokens: 10, outputTokens: 5 },
@@ -192,5 +216,11 @@ describe('createCopilotClient contract', () => {
 
     const result = await client.completeWithTools('Use tools', tools, handlers);
     expect(result.content).toBe('No tools needed.');
+
+    // Verify defineTool was called for the tool
+    const sdk = await import(COPILOT_SDK_MODULE) as { defineTool: ReturnType<typeof vi.fn> };
+    expect(sdk.defineTool).toHaveBeenCalledWith('dummy_tool', expect.objectContaining({
+      description: 'Dummy tool for contract test.',
+    }));
   });
 });

--- a/tools/evaluator/__tests__/copilot-client.test.ts
+++ b/tools/evaluator/__tests__/copilot-client.test.ts
@@ -89,8 +89,8 @@ describe('createCopilotClient contract', () => {
     });
   });
 
-  it('maps gpt-4o model to gpt-4.1 for the Copilot SDK', async () => {
-    mockCopilotSdk({ content: 'Mapped model response.', usage: { inputTokens: 10, outputTokens: 5 } });
+  it('passes model name directly to the Copilot SDK without mapping', async () => {
+    mockCopilotSdk({ content: 'Model response.', usage: { inputTokens: 10, outputTokens: 5 } });
     const createCopilotClient = await loadCopilotClientFactory();
     const client = createCopilotClient({
       provider: 'copilot',
@@ -100,14 +100,12 @@ describe('createCopilotClient contract', () => {
 
     await client.complete('Hello');
 
-    // Verify the Copilot SDK was called — the session was created successfully
-    // (if gpt-4o were passed to the SDK, it would reject it)
     const sdk = await import(COPILOT_SDK_MODULE) as { CopilotClient: ReturnType<typeof vi.fn> };
     const mockClientInstance = sdk.CopilotClient.mock.results[0]?.value as {
       createSession: ReturnType<typeof vi.fn>;
     };
     expect(mockClientInstance.createSession).toHaveBeenCalledWith(
-      expect.objectContaining({ model: 'gpt-4.1' }),
+      expect.objectContaining({ model: 'gpt-4o' }),
     );
   });
 

--- a/tools/evaluator/__tests__/discover-command.test.ts
+++ b/tools/evaluator/__tests__/discover-command.test.ts
@@ -98,7 +98,7 @@ function getCurrentEvaluationWorkflowChange(repoRoot: string): string {
   return `.github/workflows/${workflowFile}`;
 }
 
-function writeSummary(repoRoot: string, entryIds: string[]): string {
+function _writeSummary(repoRoot: string, entryIds: string[]): string {
   const summaryPath = join(repoRoot, 'summary.json');
   const summary: BenchmarkSummary = {
     lastUpdated: '2026-03-25T00:00:00Z',

--- a/tools/evaluator/__tests__/discoverer.test.ts
+++ b/tools/evaluator/__tests__/discoverer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterAll } from 'vitest';
-import { discoverChangedEntries, discoverAllEntries, filterByPreviousResults } from '../src/core/discoverer.js';
+import { discoverChangedEntries, discoverAllEntries as _discoverAllEntries, filterByPreviousResults } from '../src/core/discoverer.js';
 import type { GitClient } from '../src/adapters/git-client.js';
 import type { BenchmarkSummary } from '../src/core/types.js';
 import { join } from 'node:path';

--- a/tools/evaluator/__tests__/evaluate-provider.integration.test.ts
+++ b/tools/evaluator/__tests__/evaluate-provider.integration.test.ts
@@ -104,15 +104,25 @@ afterEach(() => {
 
 describe('evaluate command – provider selection', () => {
   it('uses copilot provider when --provider is omitted', async () => {
-    await runEvaluate([]);
+    const prev = process.env['COPILOT_GITHUB_TOKEN'];
+    process.env['COPILOT_GITHUB_TOKEN'] = 'gh-test-token';
 
-    expect(mockedCreateLLMClient).toHaveBeenCalledTimes(1);
-    expect(mockedCreateLLMClient).toHaveBeenCalledWith(
-      expect.objectContaining({ provider: 'copilot' }),
-    );
+    try {
+      await runEvaluate([]);
+
+      expect(mockedCreateLLMClient).toHaveBeenCalledTimes(1);
+      expect(mockedCreateLLMClient).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: 'copilot' }),
+      );
+    } finally {
+      if (prev === undefined) delete process.env['COPILOT_GITHUB_TOKEN'];
+      else process.env['COPILOT_GITHUB_TOKEN'] = prev;
+    }
   });
 
   it('fails when copilot initialization throws and does not fall back to openai', async () => {
+    const prev = process.env['COPILOT_GITHUB_TOKEN'];
+    process.env['COPILOT_GITHUB_TOKEN'] = 'gh-test-token';
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => {
       throw new ProcessExitError(code);
     }) as typeof process.exit);
@@ -136,6 +146,8 @@ describe('evaluate command – provider selection', () => {
         expect.objectContaining({ provider: 'openai' }),
       );
     } finally {
+      if (prev === undefined) delete process.env['COPILOT_GITHUB_TOKEN'];
+      else process.env['COPILOT_GITHUB_TOKEN'] = prev;
       exitSpy.mockRestore();
     }
   });

--- a/tools/evaluator/__tests__/evaluate-provider.integration.test.ts
+++ b/tools/evaluator/__tests__/evaluate-provider.integration.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { DiscoveredEntry, EvaluationResult } from '../src/core/types.js';
+
+vi.mock('../src/adapters/llm-client.js', () => ({
+  createLLMClient: vi.fn(() => ({
+    complete: vi.fn(),
+    completeWithTools: vi.fn(),
+  })),
+}));
+
+vi.mock('../src/adapters/file-reader.js', () => ({
+  createFileReader: vi.fn(() => ({
+    exists: vi.fn().mockReturnValue(true),
+    readFile: vi.fn(),
+    readFileRelative: vi.fn(),
+  })),
+}));
+
+vi.mock('../src/core/runner.js', () => ({
+  runEvaluation: vi.fn(async (entry: DiscoveredEntry): Promise<EvaluationResult> => ({
+    id: entry.id,
+    kind: entry.kind,
+    name: entry.id.split(':')[1] ?? entry.id,
+    assetPath: entry.assetPath,
+    model: 'gpt-4o',
+    startedAt: '2026-04-17T00:00:00.000Z',
+    finishedAt: '2026-04-17T00:00:01.000Z',
+    scenarios: [],
+    overallScore: 1,
+    passRate: 1,
+    passed: true,
+    skipped: false,
+    totalTokensInput: 0,
+    totalTokensOutput: 0,
+    source: 'manual',
+    commitSha: 'test-sha',
+  })),
+}));
+
+// Imports must come after vi.mock calls
+import { createLLMClient } from '../src/adapters/llm-client.js';
+import { buildCLI } from '../src/cli.js';
+
+const mockedCreateLLMClient = vi.mocked(createLLMClient);
+
+class ProcessExitError extends Error {
+  readonly code: number | string | null | undefined;
+
+  constructor(code: number | string | null | undefined) {
+    super(`process.exit:${String(code)}`);
+    this.code = code;
+  }
+}
+
+function writeDiscoveredEntriesFile(rootDir: string): string {
+  const entriesPath = join(rootDir, 'discovered.json');
+  const entries: { entries: DiscoveredEntry[] } = {
+    entries: [
+      {
+        id: 'skill:evaluate-provider-test',
+        kind: 'skill',
+        assetPath: 'skills/evaluate-provider-test',
+        testPath: 'tests/skills/evaluate-provider-test',
+        changedFiles: ['skills/evaluate-provider-test/SKILL.md'],
+      },
+    ],
+  };
+
+  writeFileSync(entriesPath, JSON.stringify(entries, null, 2), 'utf-8');
+  return entriesPath;
+}
+
+async function runEvaluate(args: string[]): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), 'evaluator-provider-integration-'));
+  const outputDir = join(root, 'results');
+  mkdirSync(outputDir, { recursive: true });
+  const entriesPath = writeDiscoveredEntriesFile(root);
+
+  try {
+    await buildCLI().parseAsync([
+      'node',
+      'evaluator',
+      'evaluate',
+      '--entries',
+      entriesPath,
+      '--output',
+      outputDir,
+      '--repo-root',
+      root,
+      ...args,
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+afterEach(() => {
+  mockedCreateLLMClient.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe('evaluate command – provider selection', () => {
+  it('uses copilot provider when --provider is omitted', async () => {
+    await runEvaluate([]);
+
+    expect(mockedCreateLLMClient).toHaveBeenCalledTimes(1);
+    expect(mockedCreateLLMClient).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'copilot' }),
+    );
+  });
+
+  it('fails when copilot initialization throws and does not fall back to openai', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => {
+      throw new ProcessExitError(code);
+    }) as typeof process.exit);
+
+    mockedCreateLLMClient.mockImplementationOnce((config) => {
+      if (config.provider === 'copilot') {
+        throw new Error('provider_unavailable: copilot SDK not available');
+      }
+      return { complete: vi.fn(), completeWithTools: vi.fn() };
+    });
+
+    try {
+      await expect(runEvaluate([])).rejects.toMatchObject({ code: 1 });
+
+      // createLLMClient must have been called once (for copilot), never for openai
+      expect(mockedCreateLLMClient).toHaveBeenCalledTimes(1);
+      expect(mockedCreateLLMClient).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: 'copilot' }),
+      );
+      expect(mockedCreateLLMClient).not.toHaveBeenCalledWith(
+        expect.objectContaining({ provider: 'openai' }),
+      );
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('uses openai provider when --provider openai is provided', async () => {
+    const previousKey = process.env['LLM_API_KEY'];
+    process.env['LLM_API_KEY'] = 'test-openai-key';
+
+    try {
+      await runEvaluate(['--provider', 'openai']);
+
+      expect(mockedCreateLLMClient).toHaveBeenCalledTimes(1);
+      expect(mockedCreateLLMClient).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: 'openai', apiKey: 'test-openai-key' }),
+      );
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env['LLM_API_KEY'];
+      } else {
+        process.env['LLM_API_KEY'] = previousKey;
+      }
+    }
+  });
+});

--- a/tools/evaluator/__tests__/judge.test.ts
+++ b/tools/evaluator/__tests__/judge.test.ts
@@ -100,3 +100,41 @@ describe('judgeScenario', () => {
     expect(typeof result.passed).toBe('boolean');
   });
 });
+
+describe('judgeScenario — provider-agnostic contract', () => {
+  it('accepts any LLMClient without inspecting provider identity', async () => {
+    const llmClient = makeMockLLMClient([
+      { content: 'function hello() { console.log("hello world"); }' },
+      { content: '{"score": 8, "reasoning": "Good"}' },
+    ]);
+
+    // LLMClient interface has no provider field — judge must not branch on it
+    expect('provider' in llmClient).toBe(false);
+
+    const singleRun: Scenario = { ...sampleScenario, runs: 1 };
+    const result = await judgeScenario(llmClient, singleRun);
+    expect(result.scenarioName).toBe('test-scenario');
+  });
+
+  it('records error and does NOT switch provider when complete() rejects', async () => {
+    // status 429 + ByDay message → withRetry fast-fails immediately (no sleep).
+    const copilotError = Object.assign(new Error('copilot ByDay quota exceeded'), { status: 429, headers: {}, category: 'copilot' });
+    const errorClient: LLMClient = {
+      complete: vi.fn().mockRejectedValue(copilotError),
+      completeWithTools: vi.fn().mockRejectedValue(copilotError),
+    };
+
+    const singleRun: Scenario = { ...sampleScenario, runs: 1 };
+
+    // judgeScenario must not throw; it should record a failed run
+    const result = await judgeScenario(errorClient, singleRun);
+
+    expect(result.runs).toHaveLength(1);
+    expect(result.passed).toBe(false);
+
+    // complete() called only on this client — no secondary client is ever created
+    const callCount = (errorClient.complete as ReturnType<typeof vi.fn>).mock.calls.length +
+      (errorClient.completeWithTools as ReturnType<typeof vi.fn>).mock.calls.length;
+    expect(callCount).toBeGreaterThan(0);
+  });
+});

--- a/tools/evaluator/__tests__/llm-client-factory.test.ts
+++ b/tools/evaluator/__tests__/llm-client-factory.test.ts
@@ -45,13 +45,14 @@ describe('createLLMClient provider factory', () => {
     expect(result).toBe(openAIClient);
   });
 
-  it('throws provider_unavailable for copilot provider placeholder', () => {
-    expect(() => {
-      createLLMClient({
-        provider: 'copilot',
-        model: 'gpt-4o',
-      });
-    }).toThrowError(/provider_unavailable/);
+  it('dispatches copilot provider to createCopilotClient and returns a client', () => {
+    const result = createLLMClient({
+      provider: 'copilot',
+      model: 'gpt-4o',
+    });
+    expect(result).toBeDefined();
+    expect(typeof result.complete).toBe('function');
+    expect(typeof result.completeWithTools).toBe('function');
   });
 
   it('throws provider_invalid for unsupported provider values', () => {

--- a/tools/evaluator/__tests__/llm-client-factory.test.ts
+++ b/tools/evaluator/__tests__/llm-client-factory.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LLMClient } from '../src/adapters/llm-client.js';
+
+const { mockCreateOpenAIClient } = vi.hoisted(() => ({
+  mockCreateOpenAIClient: vi.fn(),
+}));
+
+vi.mock('../src/adapters/llm/openai-client.js', () => ({
+  createOpenAIClient: mockCreateOpenAIClient,
+}));
+
+import { createLLMClient } from '../src/adapters/llm-client.js';
+
+function makeStubClient(): LLMClient {
+  return {
+    complete: vi.fn(),
+    completeWithTools: vi.fn(),
+  };
+}
+
+describe('createLLMClient provider factory', () => {
+  beforeEach(() => {
+    mockCreateOpenAIClient.mockReset();
+  });
+
+  it('dispatches openai provider to createOpenAIClient', () => {
+    const openAIClient = makeStubClient();
+    mockCreateOpenAIClient.mockReturnValue(openAIClient);
+
+    const result = createLLMClient({
+      provider: 'openai',
+      model: 'gpt-4o',
+      apiKey: 'test-key',
+      baseURL: 'https://example.test',
+      timeoutMs: 1500,
+    });
+
+    expect(mockCreateOpenAIClient).toHaveBeenCalledWith({
+      provider: 'openai',
+      model: 'gpt-4o',
+      apiKey: 'test-key',
+      baseURL: 'https://example.test',
+      timeoutMs: 1500,
+    });
+    expect(result).toBe(openAIClient);
+  });
+
+  it('throws provider_unavailable for copilot provider placeholder', () => {
+    expect(() => {
+      createLLMClient({
+        provider: 'copilot',
+        model: 'gpt-4o',
+      });
+    }).toThrowError(/provider_unavailable/);
+  });
+
+  it('throws provider_invalid for unsupported provider values', () => {
+    expect(() => {
+      createLLMClient({
+        provider: 'unsupported' as unknown as 'copilot' | 'openai',
+        model: 'gpt-4o',
+      });
+    }).toThrowError(/provider_invalid/);
+  });
+});

--- a/tools/evaluator/__tests__/report-command.test.ts
+++ b/tools/evaluator/__tests__/report-command.test.ts
@@ -25,6 +25,7 @@ function makeResult(id: string, source: EvaluationResult['source'] = 'pr'): Eval
     overallScore: 1,
     passRate: 1,
     passed: true,
+    skipped: false,
     totalTokensInput: 200,
     totalTokensOutput: 80,
     source,

--- a/tools/evaluator/__tests__/runner.test.ts
+++ b/tools/evaluator/__tests__/runner.test.ts
@@ -82,8 +82,8 @@ describe('runEvaluation — provider-agnostic contract', () => {
 
     // Evaluation must record error — no silent fallback to another provider
     expect(result.scenarios.length).toBeGreaterThanOrEqual(0);
-    // complete() should never be called on a second (fallback) client
-    expect((errorClient.complete as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(0);
+    // complete() should have been called on the injected client only
+    expect((errorClient.complete as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
     // The result itself should indicate failure (no passes when client always errors)
     expect(result.passed).toBe(false);
   });

--- a/tools/evaluator/__tests__/runner.test.ts
+++ b/tools/evaluator/__tests__/runner.test.ts
@@ -39,6 +39,56 @@ function makeMockFileReader(content: string): FileReader {
   };
 }
 
+describe('runEvaluation — provider-agnostic contract', () => {
+  const entry: DiscoveredEntry = {
+    id: 'skill:sample-skill',
+    kind: 'skill',
+    assetPath: 'skills/sample-skill',
+    testPath: 'tests/skills/sample-skill',
+    changedFiles: ['skills/sample-skill/SKILL.md'],
+  };
+
+  it('accepts any LLMClient implementation without inspecting provider identity', async () => {
+    // LLMClient has NO provider property — runner must not access it
+    const llmClient = makeMockLLMClient();
+    expect('provider' in llmClient).toBe(false);
+
+    const fileReader = makeMockFileReader(sampleScenariosYaml);
+    const result = await runEvaluation(entry, llmClient, fileReader, {
+      model: 'any-model',
+      source: 'manual',
+      commitSha: 'aaa',
+      repoRoot: '/tmp/fake-repo',
+    });
+
+    expect(result.id).toBe('skill:sample-skill');
+  });
+
+  it('does NOT switch to a fallback client when complete() rejects', async () => {
+    // status 429 + ByDay message → withRetry fast-fails immediately (no sleep).
+    const copilotError = Object.assign(new Error('copilot ByDay quota exceeded'), { status: 429, headers: {}, category: 'copilot' });
+    const errorClient: LLMClient = {
+      complete: vi.fn().mockRejectedValue(copilotError),
+      completeWithTools: vi.fn().mockRejectedValue(copilotError),
+    };
+    const fileReader = makeMockFileReader(sampleScenariosYaml);
+
+    const result = await runEvaluation(entry, errorClient, fileReader, {
+      model: 'copilot-gpt-4o',
+      source: 'manual',
+      commitSha: 'bbb',
+      repoRoot: '/tmp/fake-repo',
+    });
+
+    // Evaluation must record error — no silent fallback to another provider
+    expect(result.scenarios.length).toBeGreaterThanOrEqual(0);
+    // complete() should never be called on a second (fallback) client
+    expect((errorClient.complete as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(0);
+    // The result itself should indicate failure (no passes when client always errors)
+    expect(result.passed).toBe(false);
+  });
+});
+
 describe('runEvaluation', () => {
   const entry: DiscoveredEntry = {
     id: 'skill:sample-skill',

--- a/tools/evaluator/__tests__/runner.test.ts
+++ b/tools/evaluator/__tests__/runner.test.ts
@@ -87,6 +87,26 @@ describe('runEvaluation — provider-agnostic contract', () => {
     // The result itself should indicate failure (no passes when client always errors)
     expect(result.passed).toBe(false);
   });
+
+  it('fails fast on provider_unavailable errors without retrying', async () => {
+    const providerError = new Error('provider_unavailable: unable to create copilot session (Model "gpt-4o" is not available.)');
+    const errorClient: LLMClient = {
+      complete: vi.fn().mockRejectedValue(providerError),
+      completeWithTools: vi.fn().mockRejectedValue(providerError),
+    };
+    const fileReader = makeMockFileReader(sampleScenariosYaml);
+
+    const result = await runEvaluation(entry, errorClient, fileReader, {
+      model: 'gpt-4o',
+      source: 'manual',
+      commitSha: 'ccc',
+      repoRoot: '/tmp/fake-repo',
+    });
+
+    // Should only be called once (no retries)
+    expect((errorClient.complete as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+    expect(result.passed).toBe(false);
+  });
 });
 
 describe('runEvaluation', () => {

--- a/tools/evaluator/eslint.config.js
+++ b/tools/evaluator/eslint.config.js
@@ -1,0 +1,23 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+/** @type {import('eslint').Linter.Config[]} */
+export default [
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['src/**/*.ts', '__tests__/**/*.ts'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+    },
+    rules: {
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      'no-console': 'off',
+    },
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**'],
+  },
+];

--- a/tools/evaluator/package-lock.json
+++ b/tools/evaluator/package-lock.json
@@ -25,6 +25,7 @@
         "eslint": "^9.17.0",
         "tsx": "^4.19.2",
         "typescript": "^5.7.2",
+        "typescript-eslint": "^8.58.2",
         "vitest": "^2.1.8"
       }
     },
@@ -1340,6 +1341,288 @@
         "form-data": "^4.0.4"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/type-utils": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.58.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.2",
+        "@typescript-eslint/types": "^8.58.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.2",
+        "@typescript-eslint/tsconfig-utils": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
@@ -2187,6 +2470,24 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -3139,6 +3440,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pino": {
       "version": "9.14.0",
       "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
@@ -3706,6 +4020,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/tinypool": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
@@ -3741,6 +4072,19 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -3787,6 +4131,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.58.2",
+        "@typescript-eslint/parser": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici-types": {

--- a/tools/evaluator/package-lock.json
+++ b/tools/evaluator/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@copilot-instructions/evaluator",
       "version": "0.1.0",
       "dependencies": {
+        "@github/copilot-sdk": "^0.2.2",
         "commander": "^12.1.0",
         "openai": "^4.77.0",
         "pino": "^9.6.0",
@@ -682,6 +683,142 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@github/copilot": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.31.tgz",
+      "integrity": "sha512-AfoVW9pHsKQGtLCpPcvQ8TOwBVF8meo5srle/8cqRSsx882CpIQx5C4uNs6zwrCtqMTo8M8D6zlDIbXkLudrXw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.31",
+        "@github/copilot-darwin-x64": "1.0.31",
+        "@github/copilot-linux-arm64": "1.0.31",
+        "@github/copilot-linux-x64": "1.0.31",
+        "@github/copilot-win32-arm64": "1.0.31",
+        "@github/copilot-win32-x64": "1.0.31"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.31.tgz",
+      "integrity": "sha512-DnAbe87U55/egBu/SFdMniQfhnYjfP3ZXXhrba3DZMXQI+91iRAGfPFKAsSlekl0zfNFw8toOkiafr9Hu2lHvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.31.tgz",
+      "integrity": "sha512-mFmuYT3N1JE3zRIwCAPaXGDstL8Npa62Jey3vT4Lo003NfzQrBzvZ4ObAVMTmFQ6pRZzj39rTTKp1vLYGg+K0w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.31.tgz",
+      "integrity": "sha512-R5V7EIqn92f9YMe3zbQkW++Mw8WErDy6hA8Rr95bSJGiTVyWdj5kqPWSAPH6MLjFbC1T5cJQm/1we+QP3XO3Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.31.tgz",
+      "integrity": "sha512-LmcCGmYP9QLim/YMu5e1UlVeqCt/cuMI0fIqkdHs68h+0FGreSnHpn7nA9RbjAbQuPq9HFWeFjG5UpbAHM71Xg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.2.tgz",
+      "integrity": "sha512-VZCqS08YlUM90bUKJ7VLeIxgTTEHtfXBo84T1IUMNvXRREX2csjPH6Z+CPw3S2468RcCLvzBXcc9LtJJTLIWFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.21",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@github/copilot-sdk/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.31.tgz",
+      "integrity": "sha512-OlMPsQYFbl1hzrE0t703BwB9k8lQauQ4ETiiKpXSV4FxUb3DAU9PqWcy1pZoBjmLCni9h1ASQQKmPQ9ERJPm3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.31.tgz",
+      "integrity": "sha512-nK8uRdlKH6TNk1cjBqEPTvzWQxwnDPgNN3M5bB7TBXL6EsaFdUJePz4tqutUPoPbSKQqo+DtmJGT3/+A30ZcXg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4245,6 +4382,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/tools/evaluator/package.json
+++ b/tools/evaluator/package.json
@@ -30,6 +30,7 @@
     "eslint": "^9.17.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",
+    "typescript-eslint": "^8.58.2",
     "vitest": "^2.1.8"
   }
 }

--- a/tools/evaluator/package.json
+++ b/tools/evaluator/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@github/copilot-sdk": "^0.2.2",
     "commander": "^12.1.0",
     "openai": "^4.77.0",
     "pino": "^9.6.0",

--- a/tools/evaluator/src/adapters/llm-client.ts
+++ b/tools/evaluator/src/adapters/llm-client.ts
@@ -1,5 +1,4 @@
-import OpenAI from 'openai';
-import { logger } from '../utils/logger.js';
+import { createOpenAIClient } from './llm/openai-client.js';
 
 export interface LLMCompletionOptions {
   systemPrompt?: string;
@@ -33,141 +32,24 @@ export interface LLMClient {
   ): Promise<LLMResponse>;
 }
 
+export type LLMProvider = 'copilot' | 'openai';
+
 export interface LLMClientConfig {
-  apiKey: string;
+  provider: LLMProvider;
   model: string;
+  apiKey?: string;
   baseURL?: string | undefined;
+  workDir?: string | undefined;
+  timeoutMs?: number | undefined;
 }
 
 export function createLLMClient(config: LLMClientConfig): LLMClient {
-  const openai = new OpenAI({
-    apiKey: config.apiKey,
-    baseURL: config.baseURL,
-    defaultHeaders: {
-      'editor-version': 'copilot-cli/2.4.0',
-      'editor-plugin-version': 'copilot-cli/2.4.0',
-      'openai-intent': 'copilot-cli',
-      'user-agent': 'github-copilot-cli/2.4.0',
-      'copilot-integration-id': 'copilot-cli',
-    },
-  });
-
-  return {
-    async complete(prompt: string, options: LLMCompletionOptions = {}): Promise<LLMResponse> {
-      const messages: OpenAI.ChatCompletionMessageParam[] = [];
-
-      if (options.systemPrompt) {
-        messages.push({ role: 'system', content: options.systemPrompt });
-      }
-
-      messages.push({ role: 'user', content: prompt });
-
-      logger.debug({ model: config.model, maxTokens: options.maxTokens }, 'LLM call');
-
-      const response = await openai.chat.completions.create({
-        model: config.model,
-        messages,
-        max_tokens: options.maxTokens ?? 4000,
-        temperature: options.temperature ?? 0.7,
-      });
-
-      const choice = response.choices[0];
-      const content = choice?.message?.content ?? '';
-      const tokensInput = response.usage?.prompt_tokens ?? 0;
-      const tokensOutput = response.usage?.completion_tokens ?? 0;
-
-      return { content, tokensInput, tokensOutput };
-    },
-
-    async completeWithTools(
-      prompt: string,
-      tools: ToolDefinition[],
-      toolHandlers: Map<string, ToolHandler>,
-      options: LLMCompletionOptions = {},
-    ): Promise<LLMResponse> {
-      const messages: OpenAI.ChatCompletionMessageParam[] = [];
-
-      if (options.systemPrompt) {
-        messages.push({ role: 'system', content: options.systemPrompt });
-      }
-
-      messages.push({ role: 'user', content: prompt });
-
-      const openaiTools: OpenAI.ChatCompletionTool[] = tools.map((t) => ({
-        type: 'function' as const,
-        function: {
-          name: t.name,
-          description: t.description,
-          parameters: t.parameters,
-        },
-      }));
-
-      let totalInput = 0;
-      let totalOutput = 0;
-      const maxRounds = 10;
-
-      for (let round = 0; round < maxRounds; round++) {
-        logger.debug({ model: config.model, round, tools: tools.length }, 'LLM tool call');
-
-        const response = await openai.chat.completions.create({
-          model: config.model,
-          messages,
-          tools: openaiTools,
-          max_tokens: options.maxTokens ?? 4000,
-          temperature: options.temperature ?? 0.7,
-        });
-
-        totalInput += response.usage?.prompt_tokens ?? 0;
-        totalOutput += response.usage?.completion_tokens ?? 0;
-
-        const choice = response.choices[0];
-        if (!choice) break;
-
-        const msg = choice.message;
-
-        // If no tool calls, we have the final response
-        if (!msg.tool_calls || msg.tool_calls.length === 0) {
-          return {
-            content: msg.content ?? '',
-            tokensInput: totalInput,
-            tokensOutput: totalOutput,
-          };
-        }
-
-        // Add assistant message with tool calls
-        messages.push(msg);
-
-        // Process each tool call
-        for (const toolCall of msg.tool_calls) {
-          const handler = toolHandlers.get(toolCall.function.name);
-          let result: string;
-          if (handler) {
-            try {
-              const args = JSON.parse(toolCall.function.arguments) as Record<string, unknown>;
-              result = await handler(args);
-            } catch (err) {
-              result = `Error: ${err instanceof Error ? err.message : String(err)}`;
-            }
-          } else {
-            result = `Error: Unknown tool "${toolCall.function.name}"`;
-          }
-
-          messages.push({
-            role: 'tool',
-            tool_call_id: toolCall.id,
-            content: result,
-          });
-        }
-      }
-
-      // Max rounds reached — return whatever content we have
-      const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant');
-      const lastContent = lastAssistant && 'content' in lastAssistant ? lastAssistant.content : '';
-      return {
-        content: typeof lastContent === 'string' ? lastContent : '',
-        tokensInput: totalInput,
-        tokensOutput: totalOutput,
-      };
-    },
-  };
+  switch (config.provider) {
+    case 'openai':
+      return createOpenAIClient(config);
+    case 'copilot':
+      throw new Error('provider_unavailable: provider "copilot" is not implemented yet');
+    default:
+      throw new Error(`provider_invalid: unsupported provider "${String((config as { provider?: unknown }).provider)}"`);
+  }
 }

--- a/tools/evaluator/src/adapters/llm-client.ts
+++ b/tools/evaluator/src/adapters/llm-client.ts
@@ -42,6 +42,7 @@ export interface LLMClientConfig {
   baseURL?: string | undefined;
   workDir?: string | undefined;
   timeoutMs?: number | undefined;
+  githubToken?: string | undefined;
 }
 
 export function createLLMClient(config: LLMClientConfig): LLMClient {

--- a/tools/evaluator/src/adapters/llm-client.ts
+++ b/tools/evaluator/src/adapters/llm-client.ts
@@ -1,4 +1,5 @@
 import { createOpenAIClient } from './llm/openai-client.js';
+import { createCopilotClient } from './llm/copilot-client.js';
 
 export interface LLMCompletionOptions {
   systemPrompt?: string;
@@ -48,7 +49,7 @@ export function createLLMClient(config: LLMClientConfig): LLMClient {
     case 'openai':
       return createOpenAIClient(config);
     case 'copilot':
-      throw new Error('provider_unavailable: provider "copilot" is not implemented yet');
+      return createCopilotClient(config);
     default:
       throw new Error(`provider_invalid: unsupported provider "${String((config as { provider?: unknown }).provider)}"`);
   }

--- a/tools/evaluator/src/adapters/llm/copilot-client.ts
+++ b/tools/evaluator/src/adapters/llm/copilot-client.ts
@@ -1,19 +1,54 @@
 // @github/copilot-sdk is loaded lazily at module evaluation time so that a missing
 // SDK does not prevent other providers (e.g. openai) from loading. The dynamic
-// import is wrapped in a try/catch: if the SDK is absent, _createCopilotSession
-// remains undefined and createCopilotClient throws provider_unavailable at call time.
-type CreateCopilotSessionFn = (options: {
-  model: string;
-  workDir?: string;
-  timeoutMs?: number;
-}) => unknown;
+// import is wrapped in a try/catch: if the SDK is absent, _sdk remains undefined
+// and createCopilotClient throws provider_unavailable at call time.
 
-let _createCopilotSession: CreateCopilotSessionFn | undefined;
+type PermissionResult = { kind: string };
+type OnPermissionRequest = (req: unknown, inv: unknown) => PermissionResult;
+
+type SDKSession = {
+  sendAndWait(opts: { prompt: string }, timeout?: number): Promise<SDKAssistantMessage | undefined>;
+  on(eventType: string, handler: (event: { data: unknown }) => void): () => void;
+  disconnect(): Promise<void>;
+};
+
+type SDKAssistantMessage = {
+  type: string;
+  data: { content: string };
+};
+
+type SDKClientOptions = {
+  githubToken?: string;
+  useLoggedInUser?: boolean;
+  logLevel?: string;
+};
+
+type SDKSessionConfig = {
+  model?: string;
+  systemMessage?: { mode?: string; content?: string };
+  onPermissionRequest: OnPermissionRequest;
+  infiniteSessions?: { enabled: boolean };
+};
+
+type SDKClientInstance = {
+  start(): Promise<void>;
+  stop(): Promise<Error[]>;
+  createSession(config: SDKSessionConfig): Promise<SDKSession>;
+};
+
+type SDKClientCtor = new (options?: SDKClientOptions) => SDKClientInstance;
+
+type SDKModule = {
+  CopilotClient: SDKClientCtor;
+  approveAll: OnPermissionRequest;
+};
+
+let _sdk: SDKModule | undefined;
 try {
   const sdk = await import('@github/copilot-sdk');
-  const sdkRecord = sdk as unknown as { createCopilotSession: CreateCopilotSessionFn };
-  if (typeof sdkRecord.createCopilotSession === 'function') {
-    _createCopilotSession = sdkRecord.createCopilotSession;
+  const sdkRecord = sdk as unknown as SDKModule;
+  if (typeof sdkRecord.CopilotClient === 'function') {
+    _sdk = sdkRecord;
   }
 } catch {
   // SDK absent — provider_unavailable thrown at createCopilotClient call time
@@ -28,53 +63,8 @@ import type {
   ToolHandler,
 } from '../llm-client.js';
 
-type CopilotUsage = {
-  inputTokens?: number;
-  outputTokens?: number;
-};
-
-type CopilotResponse = {
-  assistant?: {
-    content?: unknown;
-  };
-  usage?: CopilotUsage;
-  events?: unknown[];
-};
-
-type CopilotSession = {
-  complete: (request: {
-    prompt: string;
-    model: string;
-    systemPrompt?: string;
-    maxTokens?: number;
-    temperature?: number;
-  }) => Promise<unknown>;
-};
-
 function asNumber(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : 0;
-}
-
-function extractText(content: unknown): string {
-  if (typeof content === 'string') {
-    return content;
-  }
-
-  if (Array.isArray(content)) {
-    return content.map((part) => extractText(part)).join('');
-  }
-
-  if (content && typeof content === 'object') {
-    const record = content as Record<string, unknown>;
-    if (typeof record['text'] === 'string') {
-      return record['text'];
-    }
-    if (typeof record['content'] === 'string') {
-      return record['content'];
-    }
-  }
-
-  return '';
 }
 
 function isTimeoutError(error: unknown): boolean {
@@ -82,140 +72,70 @@ function isTimeoutError(error: unknown): boolean {
   return /timeout|timed out|idle timeout/i.test(message);
 }
 
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  let timeoutId: NodeJS.Timeout | undefined;
-
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timeoutId = setTimeout(() => {
-      reject(new Error(`provider_timeout: copilot request timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-  });
-
-  return Promise.race([promise, timeoutPromise]).finally(() => {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
-  });
-}
-
-function collectResponse(result: unknown): LLMResponse {
-  const output: LLMResponse = {
-    content: '',
-    tokensInput: 0,
-    tokensOutput: 0,
-  };
-
-  const contentParts: string[] = [];
-
-  const appendFromAssistant = (assistant: unknown): void => {
-    if (!assistant || typeof assistant !== 'object') {
-      return;
-    }
-
-    const text = extractText((assistant as Record<string, unknown>)['content']);
-    if (text) {
-      contentParts.push(text);
-    }
-  };
-
-  const appendUsage = (usage: unknown): void => {
-    if (!usage || typeof usage !== 'object') {
-      return;
-    }
-
-    const usageRecord = usage as Record<string, unknown>;
-    output.tokensInput += asNumber(usageRecord['inputTokens']);
-    output.tokensOutput += asNumber(usageRecord['outputTokens']);
-  };
-
-  const appendEvent = (event: unknown): void => {
-    if (!event || typeof event !== 'object') {
-      return;
-    }
-
-    const record = event as Record<string, unknown>;
-    appendFromAssistant(record['assistant']);
-    appendUsage(record['usage']);
-
-    const deltaText = extractText(record['delta']);
-    if (deltaText) {
-      contentParts.push(deltaText);
-    }
-
-    const contentText = extractText(record['content']);
-    if (contentText) {
-      contentParts.push(contentText);
-    }
-  };
-
-  if (result && typeof result === 'object') {
-    const response = result as CopilotResponse;
-    appendFromAssistant(response.assistant);
-    appendUsage(response.usage);
-
-    if (Array.isArray(response.events)) {
-      for (const event of response.events) {
-        appendEvent(event);
-      }
-    }
-  }
-
-  output.content = contentParts.join('').trim();
-  return output;
-}
-
 export function createCopilotClient(config: LLMClientConfig): LLMClient {
   const timeoutMs = config.timeoutMs ?? 60000;
 
-  if (!_createCopilotSession) {
+  if (!_sdk) {
     throw new Error('provider_unavailable: @github/copilot-sdk is not available in this environment');
   }
 
-  const createCopilotSession = _createCopilotSession;
-
-  let session: CopilotSession;
-  try {
-    session = createCopilotSession({
-      model: config.model,
-      ...(config.workDir !== undefined ? { workDir: config.workDir } : {}),
-      timeoutMs,
-    }) as CopilotSession;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`provider_unavailable: unable to initialize copilot session (${message})`);
-  }
+  const { CopilotClient: CopilotClientCtor, approveAll } = _sdk;
 
   return {
     async complete(prompt: string, options: LLMCompletionOptions = {}): Promise<LLMResponse> {
+      const clientOptions: SDKClientOptions = config.githubToken !== undefined
+        ? { githubToken: config.githubToken, useLoggedInUser: false, logLevel: 'error' }
+        : { useLoggedInUser: true, logLevel: 'error' };
+
+      const client = new CopilotClientCtor(clientOptions);
+
       try {
-// systemPrompt is provided per-request to enforce replace semantics:
-          // each call supplies its own system prompt rather than appending to a
-          // session-level prompt, keeping inference deterministic across calls.
-          const result = await withTimeout(
-          session.complete({
-            prompt,
-            model: config.model,
-            ...(options.systemPrompt !== undefined ? { systemPrompt: options.systemPrompt } : {}),
-            ...(options.maxTokens !== undefined ? { maxTokens: options.maxTokens } : {}),
-            ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
-          }),
+        await client.start();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`provider_unavailable: unable to start copilot client (${message})`);
+      }
 
-          timeoutMs,
-        );
+      let session: SDKSession;
+      try {
+        const sessionConfig: SDKSessionConfig = {
+          model: config.model,
+          onPermissionRequest: approveAll,
+          infiniteSessions: { enabled: false },
+          // systemPrompt is provided per-request via replace mode to enforce
+          // deterministic inference across calls.
+          ...(options.systemPrompt !== undefined
+            ? { systemMessage: { mode: 'replace', content: options.systemPrompt } }
+            : {}),
+        };
+        session = await client.createSession(sessionConfig);
+      } catch (error) {
+        await client.stop().catch(() => {});
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`provider_unavailable: unable to create copilot session (${message})`);
+      }
 
-        const response = collectResponse(result);
+      let tokensInput = 0;
+      let tokensOutput = 0;
 
-        if (!response.content) {
+      // Collect token usage from assistant.usage events emitted during inference.
+      session.on('assistant.usage', (event) => {
+        const data = event.data as Record<string, unknown>;
+        tokensInput += asNumber(data['inputTokens']);
+        tokensOutput += asNumber(data['outputTokens']);
+      });
+
+      try {
+        const result = await session.sendAndWait({ prompt }, timeoutMs);
+
+        const content = result?.data?.content?.trim() ?? '';
+        if (!content) {
           throw new Error('provider_empty_response: copilot returned empty assistant content');
         }
 
-        return response;
+        return { content, tokensInput, tokensOutput };
       } catch (error) {
         if (error instanceof Error && /provider_empty_response/.test(error.message)) {
-          throw error;
-        }
-
-        if (error instanceof Error && /provider_timeout/.test(error.message)) {
           throw error;
         }
 
@@ -226,6 +146,9 @@ export function createCopilotClient(config: LLMClientConfig): LLMClient {
 
         const message = error instanceof Error ? error.message : String(error);
         throw new Error(`provider_unavailable: copilot request failed (${message})`);
+      } finally {
+        await session.disconnect().catch(() => {});
+        await client.stop().catch(() => {});
       }
     },
 

--- a/tools/evaluator/src/adapters/llm/copilot-client.ts
+++ b/tools/evaluator/src/adapters/llm/copilot-client.ts
@@ -153,14 +153,45 @@ export function createCopilotClient(config: LLMClientConfig): LLMClient {
     },
 
     async completeWithTools(
-      _prompt: string,
-      _tools: ToolDefinition[],
-      _toolHandlers: Map<string, ToolHandler>,
-      _options: LLMCompletionOptions = {},
+      prompt: string,
+      tools: ToolDefinition[],
+      toolHandlers: Map<string, ToolHandler>,
+      options: LLMCompletionOptions = {},
     ): Promise<LLMResponse> {
-      throw new Error(
-        'provider_unsupported_operation: copilot provider does not support completeWithTools',
-      );
+      // The Copilot SDK does not support native tool/function calling.
+      // Fallback: pre-call all read_file handlers to collect file contents,
+      // embed them into the prompt, then use the regular complete method.
+      const readFileTool = tools.find((t) => t.name === 'read_file');
+      const readFileHandler = toolHandlers.get('read_file');
+
+      let enrichedPrompt = prompt;
+
+      if (readFileTool && readFileHandler) {
+        // Extract available file paths from the tool description
+        const descriptionMatch = readFileTool.description.match(/Available files:\n([\s\S]*)/);
+        const filePaths = descriptionMatch
+          ? descriptionMatch[1].split('\n').map((p) => p.trim()).filter(Boolean)
+          : [];
+
+        if (filePaths.length > 0) {
+          const fileContents: string[] = [];
+
+          for (const filePath of filePaths) {
+            try {
+              const content = await readFileHandler({ path: filePath });
+              fileContents.push(`--- File: ${filePath} ---\n${content}\n--- End: ${filePath} ---`);
+            } catch {
+              // Skip files that fail to read
+            }
+          }
+
+          if (fileContents.length > 0) {
+            enrichedPrompt = `${prompt}\n\nThe following reference files are available for context:\n\n${fileContents.join('\n\n')}`;
+          }
+        }
+      }
+
+      return this.complete(enrichedPrompt, options);
     },
   };
 }

--- a/tools/evaluator/src/adapters/llm/copilot-client.ts
+++ b/tools/evaluator/src/adapters/llm/copilot-client.ts
@@ -1,0 +1,213 @@
+import { createCopilotSession } from '@github/copilot-sdk';
+import type {
+  LLMClient,
+  LLMClientConfig,
+  LLMCompletionOptions,
+  LLMResponse,
+  ToolDefinition,
+  ToolHandler,
+} from '../llm-client.js';
+
+type CopilotUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+};
+
+type CopilotResponse = {
+  assistant?: {
+    content?: unknown;
+  };
+  usage?: CopilotUsage;
+  events?: unknown[];
+};
+
+type CopilotSession = {
+  complete: (request: {
+    prompt: string;
+    model: string;
+    systemPrompt?: string;
+    maxTokens?: number;
+    temperature?: number;
+  }) => Promise<unknown>;
+};
+
+function asNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function extractText(content: unknown): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    return content.map((part) => extractText(part)).join('');
+  }
+
+  if (content && typeof content === 'object') {
+    const record = content as Record<string, unknown>;
+    if (typeof record['text'] === 'string') {
+      return record['text'];
+    }
+    if (typeof record['content'] === 'string') {
+      return record['content'];
+    }
+  }
+
+  return '';
+}
+
+function isTimeoutError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /timeout|timed out|idle timeout/i.test(message);
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeoutId: NodeJS.Timeout | undefined;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new Error(`provider_timeout: copilot request timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  });
+}
+
+function collectResponse(result: unknown): LLMResponse {
+  const output: LLMResponse = {
+    content: '',
+    tokensInput: 0,
+    tokensOutput: 0,
+  };
+
+  const contentParts: string[] = [];
+
+  const appendFromAssistant = (assistant: unknown): void => {
+    if (!assistant || typeof assistant !== 'object') {
+      return;
+    }
+
+    const text = extractText((assistant as Record<string, unknown>)['content']);
+    if (text) {
+      contentParts.push(text);
+    }
+  };
+
+  const appendUsage = (usage: unknown): void => {
+    if (!usage || typeof usage !== 'object') {
+      return;
+    }
+
+    const usageRecord = usage as Record<string, unknown>;
+    output.tokensInput += asNumber(usageRecord['inputTokens']);
+    output.tokensOutput += asNumber(usageRecord['outputTokens']);
+  };
+
+  const appendEvent = (event: unknown): void => {
+    if (!event || typeof event !== 'object') {
+      return;
+    }
+
+    const record = event as Record<string, unknown>;
+    appendFromAssistant(record['assistant']);
+    appendUsage(record['usage']);
+
+    const deltaText = extractText(record['delta']);
+    if (deltaText) {
+      contentParts.push(deltaText);
+    }
+
+    const contentText = extractText(record['content']);
+    if (contentText) {
+      contentParts.push(contentText);
+    }
+  };
+
+  if (result && typeof result === 'object') {
+    const response = result as CopilotResponse;
+    appendFromAssistant(response.assistant);
+    appendUsage(response.usage);
+
+    if (Array.isArray(response.events)) {
+      for (const event of response.events) {
+        appendEvent(event);
+      }
+    }
+  }
+
+  output.content = contentParts.join('').trim();
+  return output;
+}
+
+export function createCopilotClient(config: LLMClientConfig): LLMClient {
+  const timeoutMs = config.timeoutMs ?? 60000;
+
+  let session: CopilotSession;
+  try {
+    session = createCopilotSession({
+      model: config.model,
+      workDir: config.workDir,
+      timeoutMs,
+    }) as CopilotSession;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`provider_unavailable: unable to initialize copilot session (${message})`);
+  }
+
+  return {
+    async complete(prompt: string, options: LLMCompletionOptions = {}): Promise<LLMResponse> {
+      try {
+        const result = await withTimeout(
+          session.complete({
+            prompt,
+            model: config.model,
+            systemPrompt: options.systemPrompt,
+            maxTokens: options.maxTokens,
+            temperature: options.temperature,
+          }),
+          timeoutMs,
+        );
+
+        const response = collectResponse(result);
+
+        if (!response.content) {
+          throw new Error('provider_empty_response: copilot returned empty assistant content');
+        }
+
+        return response;
+      } catch (error) {
+        if (error instanceof Error && /provider_empty_response/.test(error.message)) {
+          throw error;
+        }
+
+        if (error instanceof Error && /provider_timeout/.test(error.message)) {
+          throw error;
+        }
+
+        if (isTimeoutError(error)) {
+          const message = error instanceof Error ? error.message : String(error);
+          throw new Error(`provider_timeout: copilot request timed out (${message})`);
+        }
+
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`provider_unavailable: copilot request failed (${message})`);
+      }
+    },
+
+    async completeWithTools(
+      _prompt: string,
+      _tools: ToolDefinition[],
+      _toolHandlers: Map<string, ToolHandler>,
+      _options: LLMCompletionOptions = {},
+    ): Promise<LLMResponse> {
+      throw new Error(
+        'provider_unsupported_operation: copilot provider does not support completeWithTools',
+      );
+    },
+  };
+}

--- a/tools/evaluator/src/adapters/llm/copilot-client.ts
+++ b/tools/evaluator/src/adapters/llm/copilot-client.ts
@@ -62,6 +62,7 @@ import type {
   ToolDefinition,
   ToolHandler,
 } from '../llm-client.js';
+import { logger } from '../../utils/logger.js';
 
 function asNumber(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : 0;
@@ -159,15 +160,20 @@ export function createCopilotClient(config: LLMClientConfig): LLMClient {
       options: LLMCompletionOptions = {},
     ): Promise<LLMResponse> {
       // The Copilot SDK does not support native tool/function calling.
-      // Fallback: pre-call all read_file handlers to collect file contents,
-      // embed them into the prompt, then use the regular complete method.
+      // Fallback: for the read_file tool (used by the evaluator to provide
+      // skill documentation context), pre-call the handler for every available
+      // file, embed the contents into the prompt, then delegate to complete().
+      // Other tool types are not handled — they will simply be ignored and
+      // the prompt is sent as-is.
       const readFileTool = tools.find((t) => t.name === 'read_file');
       const readFileHandler = toolHandlers.get('read_file');
 
       let enrichedPrompt = prompt;
 
       if (readFileTool && readFileHandler) {
-        // Extract available file paths from the tool description
+        // Extract available file paths from the tool description.
+        // The description format is set by judge.ts buildReadFileTools():
+        //   "Read a documentation file … Available files:\npath1\npath2"
         const descriptionMatch = readFileTool.description.match(/Available files:\n([\s\S]*)/);
         const filePaths = descriptionMatch
           ? descriptionMatch[1].split('\n').map((p) => p.trim()).filter(Boolean)
@@ -180,8 +186,8 @@ export function createCopilotClient(config: LLMClientConfig): LLMClient {
             try {
               const content = await readFileHandler({ path: filePath });
               fileContents.push(`--- File: ${filePath} ---\n${content}\n--- End: ${filePath} ---`);
-            } catch {
-              // Skip files that fail to read
+            } catch (err) {
+              logger.warn({ err, path: filePath }, 'Skipping file in completeWithTools fallback');
             }
           }
 

--- a/tools/evaluator/src/adapters/llm/copilot-client.ts
+++ b/tools/evaluator/src/adapters/llm/copilot-client.ts
@@ -73,23 +73,8 @@ function isTimeoutError(error: unknown): boolean {
   return /timeout|timed out|idle timeout/i.test(message);
 }
 
-/**
- * The Copilot SDK supports a different model catalog than the raw OpenAI API.
- * Map common OpenAI model names to their Copilot SDK equivalents so the
- * evaluator works out of the box with the workflow's default model (`gpt-4o`).
- */
-const COPILOT_MODEL_MAP: Record<string, string> = {
-  'gpt-4o': 'gpt-4.1',
-  'gpt-4o-mini': 'gpt-4.1-mini',
-};
-
-function resolveCopilotModel(model: string): string {
-  return COPILOT_MODEL_MAP[model] ?? model;
-}
-
 export function createCopilotClient(config: LLMClientConfig): LLMClient {
   const timeoutMs = config.timeoutMs ?? 60000;
-  const resolvedModel = resolveCopilotModel(config.model);
 
   if (!_sdk) {
     throw new Error('provider_unavailable: @github/copilot-sdk is not available in this environment');
@@ -115,7 +100,7 @@ export function createCopilotClient(config: LLMClientConfig): LLMClient {
       let session: SDKSession;
       try {
         const sessionConfig: SDKSessionConfig = {
-          model: resolvedModel,
+          model: config.model,
           onPermissionRequest: approveAll,
           infiniteSessions: { enabled: false },
           // systemPrompt is provided per-request via replace mode to enforce
@@ -190,7 +175,7 @@ export function createCopilotClient(config: LLMClientConfig): LLMClient {
         // The description format is set by judge.ts buildReadFileTools():
         //   "Read a documentation file … Available files:\npath1\npath2"
         const descriptionMatch = readFileTool.description.match(/Available files:\n([\s\S]*)/);
-        const filePaths = descriptionMatch
+        const filePaths = descriptionMatch?.[1]
           ? descriptionMatch[1].split('\n').map((p) => p.trim()).filter(Boolean)
           : [];
 

--- a/tools/evaluator/src/adapters/llm/copilot-client.ts
+++ b/tools/evaluator/src/adapters/llm/copilot-client.ts
@@ -6,6 +6,14 @@
 type PermissionResult = { kind: string };
 type OnPermissionRequest = (req: unknown, inv: unknown) => PermissionResult;
 
+type SDKTool = {
+  name: string;
+  description?: string;
+  parameters?: Record<string, unknown>;
+  handler: (args: unknown, invocation: unknown) => Promise<unknown> | unknown;
+  skipPermission?: boolean;
+};
+
 type SDKSession = {
   sendAndWait(opts: { prompt: string }, timeout?: number): Promise<SDKAssistantMessage | undefined>;
   on(eventType: string, handler: (event: { data: unknown }) => void): () => void;
@@ -28,6 +36,7 @@ type SDKSessionConfig = {
   systemMessage?: { mode?: string; content?: string };
   onPermissionRequest: OnPermissionRequest;
   infiniteSessions?: { enabled: boolean };
+  tools?: SDKTool[];
 };
 
 type SDKClientInstance = {
@@ -38,9 +47,17 @@ type SDKClientInstance = {
 
 type SDKClientCtor = new (options?: SDKClientOptions) => SDKClientInstance;
 
+type DefineToolFn = (name: string, config: {
+  description?: string;
+  parameters?: Record<string, unknown>;
+  handler: (args: unknown, invocation: unknown) => Promise<unknown> | unknown;
+  skipPermission?: boolean;
+}) => SDKTool;
+
 type SDKModule = {
   CopilotClient: SDKClientCtor;
   approveAll: OnPermissionRequest;
+  defineTool: DefineToolFn;
 };
 
 let _sdk: SDKModule | undefined;
@@ -159,45 +176,88 @@ export function createCopilotClient(config: LLMClientConfig): LLMClient {
       toolHandlers: Map<string, ToolHandler>,
       options: LLMCompletionOptions = {},
     ): Promise<LLMResponse> {
-      // The Copilot SDK does not support native tool/function calling.
-      // Fallback: for the read_file tool (used by the evaluator to provide
-      // skill documentation context), pre-call the handler for every available
-      // file, embed the contents into the prompt, then delegate to complete().
-      // Other tool types are not handled — they will simply be ignored and
-      // the prompt is sent as-is.
-      const readFileTool = tools.find((t) => t.name === 'read_file');
-      const readFileHandler = toolHandlers.get('read_file');
-
-      let enrichedPrompt = prompt;
-
-      if (readFileTool && readFileHandler) {
-        // Extract available file paths from the tool description.
-        // The description format is set by judge.ts buildReadFileTools():
-        //   "Read a documentation file … Available files:\npath1\npath2"
-        const descriptionMatch = readFileTool.description.match(/Available files:\n([\s\S]*)/);
-        const filePaths = descriptionMatch?.[1]
-          ? descriptionMatch[1].split('\n').map((p) => p.trim()).filter(Boolean)
-          : [];
-
-        if (filePaths.length > 0) {
-          const fileContents: string[] = [];
-
-          for (const filePath of filePaths) {
-            try {
-              const content = await readFileHandler({ path: filePath });
-              fileContents.push(`--- File: ${filePath} ---\n${content}\n--- End: ${filePath} ---`);
-            } catch (err) {
-              logger.warn({ err, path: filePath }, 'Skipping file in completeWithTools fallback');
+      // Convert evaluator tool definitions + handlers into SDK Tool objects
+      // so the Copilot agent natively calls them during inference.
+      const sdkTools: SDKTool[] = tools.map((tool) => {
+        const handler = toolHandlers.get(tool.name);
+        return _sdk!.defineTool(tool.name, {
+          description: tool.description,
+          parameters: tool.parameters,
+          handler: async (args: unknown) => {
+            if (!handler) {
+              return `Tool "${tool.name}" has no handler registered.`;
             }
-          }
+            return handler(args as Record<string, unknown>);
+          },
+          skipPermission: true,
+        });
+      });
 
-          if (fileContents.length > 0) {
-            enrichedPrompt = `${prompt}\n\nThe following reference files are available for context:\n\n${fileContents.join('\n\n')}`;
-          }
-        }
+      const clientOptions: SDKClientOptions = config.githubToken !== undefined
+        ? { githubToken: config.githubToken, useLoggedInUser: false, logLevel: 'error' }
+        : { useLoggedInUser: true, logLevel: 'error' };
+
+      const client = new CopilotClientCtor(clientOptions);
+
+      try {
+        await client.start();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`provider_unavailable: unable to start copilot client (${message})`);
       }
 
-      return this.complete(enrichedPrompt, options);
+      let session: SDKSession;
+      try {
+        const sessionConfig: SDKSessionConfig = {
+          model: config.model,
+          onPermissionRequest: approveAll,
+          infiniteSessions: { enabled: false },
+          tools: sdkTools,
+          ...(options.systemPrompt !== undefined
+            ? { systemMessage: { mode: 'replace', content: options.systemPrompt } }
+            : {}),
+        };
+        session = await client.createSession(sessionConfig);
+      } catch (error) {
+        await client.stop().catch(() => {});
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`provider_unavailable: unable to create copilot session (${message})`);
+      }
+
+      let tokensInput = 0;
+      let tokensOutput = 0;
+
+      session.on('assistant.usage', (event) => {
+        const data = event.data as Record<string, unknown>;
+        tokensInput += asNumber(data['inputTokens']);
+        tokensOutput += asNumber(data['outputTokens']);
+      });
+
+      try {
+        const result = await session.sendAndWait({ prompt }, timeoutMs);
+
+        const content = result?.data?.content?.trim() ?? '';
+        if (!content) {
+          throw new Error('provider_empty_response: copilot returned empty assistant content');
+        }
+
+        return { content, tokensInput, tokensOutput };
+      } catch (error) {
+        if (error instanceof Error && /provider_empty_response/.test(error.message)) {
+          throw error;
+        }
+
+        if (isTimeoutError(error)) {
+          const message = error instanceof Error ? error.message : String(error);
+          throw new Error(`provider_timeout: copilot request timed out (${message})`);
+        }
+
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`provider_unavailable: copilot request failed (${message})`);
+      } finally {
+        await session.disconnect().catch(() => {});
+        await client.stop().catch(() => {});
+      }
     },
   };
 }

--- a/tools/evaluator/src/adapters/llm/copilot-client.ts
+++ b/tools/evaluator/src/adapters/llm/copilot-client.ts
@@ -1,4 +1,21 @@
-import { createCopilotSession } from '@github/copilot-sdk';
+// @github/copilot-sdk is loaded lazily at module evaluation time so that a missing
+// SDK does not prevent other providers (e.g. openai) from loading. The dynamic
+// import is wrapped in a try/catch: if the SDK is absent, _createCopilotSession
+// remains undefined and createCopilotClient throws provider_unavailable at call time.
+type CreateCopilotSessionFn = (options: {
+  model: string;
+  workDir?: string;
+  timeoutMs?: number;
+}) => unknown;
+
+let _createCopilotSession: CreateCopilotSessionFn | undefined;
+try {
+  const sdk = await import('@github/copilot-sdk');
+  _createCopilotSession = (sdk as { createCopilotSession: CreateCopilotSessionFn }).createCopilotSession;
+} catch {
+  // SDK absent — provider_unavailable thrown at createCopilotClient call time
+}
+
 import type {
   LLMClient,
   LLMClientConfig,
@@ -147,6 +164,12 @@ function collectResponse(result: unknown): LLMResponse {
 export function createCopilotClient(config: LLMClientConfig): LLMClient {
   const timeoutMs = config.timeoutMs ?? 60000;
 
+  if (!_createCopilotSession) {
+    throw new Error('provider_unavailable: @github/copilot-sdk is not available in this environment');
+  }
+
+  const createCopilotSession = _createCopilotSession;
+
   let session: CopilotSession;
   try {
     session = createCopilotSession({
@@ -162,7 +185,10 @@ export function createCopilotClient(config: LLMClientConfig): LLMClient {
   return {
     async complete(prompt: string, options: LLMCompletionOptions = {}): Promise<LLMResponse> {
       try {
-        const result = await withTimeout(
+// systemPrompt is provided per-request to enforce replace semantics:
+          // each call supplies its own system prompt rather than appending to a
+          // session-level prompt, keeping inference deterministic across calls.
+          const result = await withTimeout(
           session.complete({
             prompt,
             model: config.model,

--- a/tools/evaluator/src/adapters/llm/copilot-client.ts
+++ b/tools/evaluator/src/adapters/llm/copilot-client.ts
@@ -97,6 +97,10 @@ export function createCopilotClient(config: LLMClientConfig): LLMClient {
     throw new Error('provider_unavailable: @github/copilot-sdk is not available in this environment');
   }
 
+  if (config.githubToken !== undefined && config.githubToken.trim() === '') {
+    throw new Error('provider_unavailable: githubToken is set but empty — check your COPILOT_GITHUB_TOKEN secret');
+  }
+
   const { CopilotClient: CopilotClientCtor, approveAll } = _sdk;
 
   return {

--- a/tools/evaluator/src/adapters/llm/copilot-client.ts
+++ b/tools/evaluator/src/adapters/llm/copilot-client.ts
@@ -11,7 +11,10 @@ type CreateCopilotSessionFn = (options: {
 let _createCopilotSession: CreateCopilotSessionFn | undefined;
 try {
   const sdk = await import('@github/copilot-sdk');
-  _createCopilotSession = (sdk as { createCopilotSession: CreateCopilotSessionFn }).createCopilotSession;
+  const sdkRecord = sdk as unknown as { createCopilotSession: CreateCopilotSessionFn };
+  if (typeof sdkRecord.createCopilotSession === 'function') {
+    _createCopilotSession = sdkRecord.createCopilotSession;
+  }
 } catch {
   // SDK absent — provider_unavailable thrown at createCopilotClient call time
 }
@@ -174,7 +177,7 @@ export function createCopilotClient(config: LLMClientConfig): LLMClient {
   try {
     session = createCopilotSession({
       model: config.model,
-      workDir: config.workDir,
+      ...(config.workDir !== undefined ? { workDir: config.workDir } : {}),
       timeoutMs,
     }) as CopilotSession;
   } catch (error) {
@@ -192,10 +195,11 @@ export function createCopilotClient(config: LLMClientConfig): LLMClient {
           session.complete({
             prompt,
             model: config.model,
-            systemPrompt: options.systemPrompt,
-            maxTokens: options.maxTokens,
-            temperature: options.temperature,
+            ...(options.systemPrompt !== undefined ? { systemPrompt: options.systemPrompt } : {}),
+            ...(options.maxTokens !== undefined ? { maxTokens: options.maxTokens } : {}),
+            ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
           }),
+
           timeoutMs,
         );
 

--- a/tools/evaluator/src/adapters/llm/copilot-client.ts
+++ b/tools/evaluator/src/adapters/llm/copilot-client.ts
@@ -73,8 +73,23 @@ function isTimeoutError(error: unknown): boolean {
   return /timeout|timed out|idle timeout/i.test(message);
 }
 
+/**
+ * The Copilot SDK supports a different model catalog than the raw OpenAI API.
+ * Map common OpenAI model names to their Copilot SDK equivalents so the
+ * evaluator works out of the box with the workflow's default model (`gpt-4o`).
+ */
+const COPILOT_MODEL_MAP: Record<string, string> = {
+  'gpt-4o': 'gpt-4.1',
+  'gpt-4o-mini': 'gpt-4.1-mini',
+};
+
+function resolveCopilotModel(model: string): string {
+  return COPILOT_MODEL_MAP[model] ?? model;
+}
+
 export function createCopilotClient(config: LLMClientConfig): LLMClient {
   const timeoutMs = config.timeoutMs ?? 60000;
+  const resolvedModel = resolveCopilotModel(config.model);
 
   if (!_sdk) {
     throw new Error('provider_unavailable: @github/copilot-sdk is not available in this environment');
@@ -100,7 +115,7 @@ export function createCopilotClient(config: LLMClientConfig): LLMClient {
       let session: SDKSession;
       try {
         const sessionConfig: SDKSessionConfig = {
-          model: config.model,
+          model: resolvedModel,
           onPermissionRequest: approveAll,
           infiniteSessions: { enabled: false },
           // systemPrompt is provided per-request via replace mode to enforce

--- a/tools/evaluator/src/adapters/llm/openai-client.ts
+++ b/tools/evaluator/src/adapters/llm/openai-client.ts
@@ -10,10 +10,6 @@ import type {
 } from '../llm-client.js';
 
 export function createOpenAIClient(config: LLMClientConfig): LLMClient {
-  if (!config.apiKey) {
-    throw new Error('openai_api_key_required: LLM API key is required for provider "openai"');
-  }
-
   const openai = new OpenAI({
     apiKey: config.apiKey,
     baseURL: config.baseURL,

--- a/tools/evaluator/src/adapters/llm/openai-client.ts
+++ b/tools/evaluator/src/adapters/llm/openai-client.ts
@@ -1,0 +1,144 @@
+import OpenAI from 'openai';
+import { logger } from '../../utils/logger.js';
+import type {
+  LLMClient,
+  LLMClientConfig,
+  LLMCompletionOptions,
+  LLMResponse,
+  ToolDefinition,
+  ToolHandler,
+} from '../llm-client.js';
+
+export function createOpenAIClient(config: LLMClientConfig): LLMClient {
+  if (!config.apiKey) {
+    throw new Error('openai_api_key_required: LLM API key is required for provider "openai"');
+  }
+
+  const openai = new OpenAI({
+    apiKey: config.apiKey,
+    baseURL: config.baseURL,
+    timeout: config.timeoutMs,
+    defaultHeaders: {
+      'editor-version': 'copilot-cli/2.4.0',
+      'editor-plugin-version': 'copilot-cli/2.4.0',
+      'openai-intent': 'copilot-cli',
+      'user-agent': 'github-copilot-cli/2.4.0',
+      'copilot-integration-id': 'copilot-cli',
+    },
+  });
+
+  return {
+    async complete(prompt: string, options: LLMCompletionOptions = {}): Promise<LLMResponse> {
+      const messages: OpenAI.ChatCompletionMessageParam[] = [];
+
+      if (options.systemPrompt) {
+        messages.push({ role: 'system', content: options.systemPrompt });
+      }
+
+      messages.push({ role: 'user', content: prompt });
+
+      logger.debug({ model: config.model, maxTokens: options.maxTokens }, 'LLM call');
+
+      const response = await openai.chat.completions.create({
+        model: config.model,
+        messages,
+        max_tokens: options.maxTokens ?? 4000,
+        temperature: options.temperature ?? 0.7,
+      });
+
+      const choice = response.choices[0];
+      const content = choice?.message?.content ?? '';
+      const tokensInput = response.usage?.prompt_tokens ?? 0;
+      const tokensOutput = response.usage?.completion_tokens ?? 0;
+
+      return { content, tokensInput, tokensOutput };
+    },
+
+    async completeWithTools(
+      prompt: string,
+      tools: ToolDefinition[],
+      toolHandlers: Map<string, ToolHandler>,
+      options: LLMCompletionOptions = {},
+    ): Promise<LLMResponse> {
+      const messages: OpenAI.ChatCompletionMessageParam[] = [];
+
+      if (options.systemPrompt) {
+        messages.push({ role: 'system', content: options.systemPrompt });
+      }
+
+      messages.push({ role: 'user', content: prompt });
+
+      const openaiTools: OpenAI.ChatCompletionTool[] = tools.map((t) => ({
+        type: 'function' as const,
+        function: {
+          name: t.name,
+          description: t.description,
+          parameters: t.parameters,
+        },
+      }));
+
+      let totalInput = 0;
+      let totalOutput = 0;
+      const maxRounds = 10;
+
+      for (let round = 0; round < maxRounds; round++) {
+        logger.debug({ model: config.model, round, tools: tools.length }, 'LLM tool call');
+
+        const response = await openai.chat.completions.create({
+          model: config.model,
+          messages,
+          tools: openaiTools,
+          max_tokens: options.maxTokens ?? 4000,
+          temperature: options.temperature ?? 0.7,
+        });
+
+        totalInput += response.usage?.prompt_tokens ?? 0;
+        totalOutput += response.usage?.completion_tokens ?? 0;
+
+        const choice = response.choices[0];
+        if (!choice) break;
+
+        const msg = choice.message;
+
+        if (!msg.tool_calls || msg.tool_calls.length === 0) {
+          return {
+            content: msg.content ?? '',
+            tokensInput: totalInput,
+            tokensOutput: totalOutput,
+          };
+        }
+
+        messages.push(msg);
+
+        for (const toolCall of msg.tool_calls) {
+          const handler = toolHandlers.get(toolCall.function.name);
+          let result: string;
+          if (handler) {
+            try {
+              const args = JSON.parse(toolCall.function.arguments) as Record<string, unknown>;
+              result = await handler(args);
+            } catch (err) {
+              result = `Error: ${err instanceof Error ? err.message : String(err)}`;
+            }
+          } else {
+            result = `Error: Unknown tool "${toolCall.function.name}"`;
+          }
+
+          messages.push({
+            role: 'tool',
+            tool_call_id: toolCall.id,
+            content: result,
+          });
+        }
+      }
+
+      const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant');
+      const lastContent = lastAssistant && 'content' in lastAssistant ? lastAssistant.content : '';
+      return {
+        content: typeof lastContent === 'string' ? lastContent : '',
+        tokensInput: totalInput,
+        tokensOutput: totalOutput,
+      };
+    },
+  };
+}

--- a/tools/evaluator/src/cli.ts
+++ b/tools/evaluator/src/cli.ts
@@ -72,6 +72,7 @@ export function buildCLI(): Command {
         }
 
         logger.info(result, 'Discovery complete');
+        mkdirSync(dirname(opts.output), { recursive: true });
         writeFileSync(opts.output, JSON.stringify(result, null, 2), 'utf-8');
         logger.info({ output: opts.output }, 'Discovery result written');
       } catch (err) {

--- a/tools/evaluator/src/cli.ts
+++ b/tools/evaluator/src/cli.ts
@@ -111,7 +111,7 @@ export function buildCLI(): Command {
         const llmClient = createLLMClient({
           provider: opts.provider,
           model: opts.model,
-          apiKey,
+          ...(apiKey !== undefined ? { apiKey } : {}),
           workDir: opts.repoRoot,
         });
         const fileReader = createFileReader();

--- a/tools/evaluator/src/cli.ts
+++ b/tools/evaluator/src/cli.ts
@@ -93,7 +93,7 @@ export function buildCLI(): Command {
     .option('--source <source>', 'Evaluation source', 'manual')
     .option('--commit-sha <sha>', 'Commit SHA being evaluated', 'unknown')
     .action(async (opts: { entries: string; provider: LLMProvider; model: string; output: string; repoRoot: string; source: string; commitSha: string }) => {
-      const githubToken = process.env['GITHUB_TOKEN'];
+      const githubToken = process.env['COPILOT_GITHUB_TOKEN'];
       const apiKey = process.env['LLM_API_KEY'];
       if (opts.provider === 'openai' && !apiKey) {
         logger.error('LLM_API_KEY environment variable is required');

--- a/tools/evaluator/src/cli.ts
+++ b/tools/evaluator/src/cli.ts
@@ -94,6 +94,7 @@ export function buildCLI(): Command {
     .option('--commit-sha <sha>', 'Commit SHA being evaluated', 'unknown')
     .action(async (opts: { entries: string; provider: LLMProvider; model: string; output: string; repoRoot: string; source: string; commitSha: string }) => {
       const apiKey = process.env['LLM_API_KEY'];
+      const githubToken = process.env['GITHUB_TOKEN'];
       if (opts.provider === 'openai' && !apiKey) {
         logger.error('LLM_API_KEY environment variable is required');
         process.exit(1);
@@ -113,6 +114,7 @@ export function buildCLI(): Command {
           provider: opts.provider,
           model: opts.model,
           ...(apiKey !== undefined ? { apiKey } : {}),
+          ...(githubToken !== undefined ? { githubToken } : {}),
           workDir: opts.repoRoot,
         });
         const fileReader = createFileReader();

--- a/tools/evaluator/src/cli.ts
+++ b/tools/evaluator/src/cli.ts
@@ -93,8 +93,8 @@ export function buildCLI(): Command {
     .option('--source <source>', 'Evaluation source', 'manual')
     .option('--commit-sha <sha>', 'Commit SHA being evaluated', 'unknown')
     .action(async (opts: { entries: string; provider: LLMProvider; model: string; output: string; repoRoot: string; source: string; commitSha: string }) => {
-      const apiKey = process.env['LLM_API_KEY'];
       const githubToken = process.env['GITHUB_TOKEN'];
+      const apiKey = process.env['LLM_API_KEY'];
       if (opts.provider === 'openai' && !apiKey) {
         logger.error('LLM_API_KEY environment variable is required');
         process.exit(1);

--- a/tools/evaluator/src/cli.ts
+++ b/tools/evaluator/src/cli.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, InvalidArgumentError } from 'commander';
 import { writeFileSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -12,8 +12,17 @@ import { generatePRComment } from './reporters/markdown-reporter.js';
 import { updateBenchmarkSummary } from './reporters/benchmark-reporter.js';
 import { logger } from './utils/logger.js';
 import type { DiscoveredEntry, EvaluationResult } from './core/types.js';
+import type { LLMProvider } from './adapters/llm-client.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function parseProvider(value: string): LLMProvider {
+  if (value === 'copilot' || value === 'openai') {
+    return value;
+  }
+
+  throw new InvalidArgumentError(`provider must be one of: copilot, openai (received: ${value})`);
+}
 
 export function buildCLI(): Command {
   const program = new Command();
@@ -76,14 +85,15 @@ export function buildCLI(): Command {
     .command('evaluate')
     .description('Run evaluation for discovered entries')
     .requiredOption('--entries <path>', 'Path to discovered.json from discover command')
+    .option('--provider <provider>', 'LLM provider: copilot | openai', parseProvider, 'copilot')
     .option('--model <model>', 'LLM model to use', 'gpt-4o')
     .option('--output <dir>', 'Output directory for results', 'results')
     .option('--repo-root <path>', 'Repository root path', process.cwd())
     .option('--source <source>', 'Evaluation source', 'manual')
     .option('--commit-sha <sha>', 'Commit SHA being evaluated', 'unknown')
-    .action(async (opts: { entries: string; model: string; output: string; repoRoot: string; source: string; commitSha: string }) => {
+    .action(async (opts: { entries: string; provider: LLMProvider; model: string; output: string; repoRoot: string; source: string; commitSha: string }) => {
       const apiKey = process.env['LLM_API_KEY'];
-      if (!apiKey) {
+      if (opts.provider === 'openai' && !apiKey) {
         logger.error('LLM_API_KEY environment variable is required');
         process.exit(1);
       }
@@ -98,7 +108,12 @@ export function buildCLI(): Command {
         }
 
         mkdirSync(opts.output, { recursive: true });
-        const llmClient = createLLMClient({ apiKey, model: opts.model });
+        const llmClient = createLLMClient({
+          provider: opts.provider,
+          model: opts.model,
+          apiKey,
+          workDir: opts.repoRoot,
+        });
         const fileReader = createFileReader();
         const results: EvaluationResult[] = [];
 

--- a/tools/evaluator/src/cli.ts
+++ b/tools/evaluator/src/cli.ts
@@ -93,10 +93,14 @@ export function buildCLI(): Command {
     .option('--source <source>', 'Evaluation source', 'manual')
     .option('--commit-sha <sha>', 'Commit SHA being evaluated', 'unknown')
     .action(async (opts: { entries: string; provider: LLMProvider; model: string; output: string; repoRoot: string; source: string; commitSha: string }) => {
-      const githubToken = process.env['COPILOT_GITHUB_TOKEN'];
+      const githubToken = process.env['COPILOT_GITHUB_TOKEN'] || undefined;
       const apiKey = process.env['LLM_API_KEY'];
       if (opts.provider === 'openai' && !apiKey) {
         logger.error('LLM_API_KEY environment variable is required');
+        process.exit(1);
+      }
+      if (opts.provider === 'copilot' && !githubToken) {
+        logger.error('COPILOT_GITHUB_TOKEN environment variable is required for copilot provider');
         process.exit(1);
       }
 

--- a/tools/evaluator/src/cli.ts
+++ b/tools/evaluator/src/cli.ts
@@ -87,7 +87,7 @@ export function buildCLI(): Command {
     .description('Run evaluation for discovered entries')
     .requiredOption('--entries <path>', 'Path to discovered.json from discover command')
     .option('--provider <provider>', 'LLM provider: copilot | openai', parseProvider, 'copilot')
-    .option('--model <model>', 'LLM model to use', 'gpt-4o')
+    .option('--model <model>', 'LLM model to use', 'gpt-4.1')
     .option('--output <dir>', 'Output directory for results', 'results')
     .option('--repo-root <path>', 'Repository root path', process.cwd())
     .option('--source <source>', 'Evaluation source', 'manual')

--- a/tools/evaluator/src/core/runner.ts
+++ b/tools/evaluator/src/core/runner.ts
@@ -5,7 +5,7 @@ import { ScenariosFileSchema } from '../config/schema.js';
 import { judgeScenario } from './judge.js';
 import { logger } from '../utils/logger.js';
 import { parse } from 'yaml';
-import { readdirSync, statSync } from 'node:fs';
+import { readdirSync, statSync as _statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
 /**

--- a/tools/evaluator/src/utils/retry.ts
+++ b/tools/evaluator/src/utils/retry.ts
@@ -86,6 +86,15 @@ function getRetryDelay(err: unknown, fallbackDelay: number): number {
   return fallbackDelay;
 }
 
+/**
+ * Returns true when the error is a provider-level configuration error
+ * (e.g. model not available, SDK absent) that cannot be resolved by retrying.
+ */
+function isNonRetryableProviderError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return /provider_unavailable|provider_unsupported_operation/.test(err.message);
+}
+
 export async function withRetry<T>(
   fn: () => Promise<T>,
   options: RetryOptions = {},
@@ -109,6 +118,12 @@ export async function withRetry<T>(
       // Daily / hourly quotas cannot be resolved by retrying in CI — fail fast
       if (isNonRetryableRateLimit(err)) {
         logger.error({ err }, 'Long-term rate limit exceeded — not retrying (quota is per-day or per-hour)');
+        throw err;
+      }
+
+      // Provider configuration errors (model not available, SDK absent) — fail fast
+      if (isNonRetryableProviderError(err)) {
+        logger.error({ err }, 'Non-retryable provider error — stopping immediately');
         throw err;
       }
 


### PR DESCRIPTION
This pull request introduces Copilot SDK provider support to the evaluator, enabling selection between Copilot and OpenAI as LLM providers, with Copilot as the default. It adds a provider abstraction, updates the CLI to accept a `--provider` flag, and implements robust error handling and test coverage for provider selection and failure modes. Additionally, new and updated tests ensure correct provider wiring, error messaging, and contract adherence.

**Copilot SDK Provider Integration and Abstraction**

* Added a comprehensive design document outlining the provider abstraction, Copilot implementation, error handling, and testing strategy for supporting both Copilot and OpenAI as LLM providers in the evaluator (`docs/superpowers/specs/2026-04-16-copilot-sdk-evaluator-provider-design.md`).

**Provider Selection and CLI Updates**

* Implemented and tested CLI support for the `--provider` flag, defaulting to `copilot`, with validation and error handling for unsupported values and missing environment variables (`tools/evaluator/__tests__/cli-provider.test.ts`).

**Copilot Adapter and Contract Testing**

* Added contract tests for the Copilot client adapter, verifying correct token accounting, error propagation, and unsupported operation handling (`tools/evaluator/__tests__/copilot-client.test.ts`).

**Test and Typing Improvements**

* Updated test result objects to include the new `skipped` field for consistency with the evaluation result schema (`tools/evaluator/__tests__/benchmark-summary.test.ts`).
* Minor refactors to test utility function names for clarity and to avoid naming conflicts (`tools/evaluator/__tests__/discover-command.test.ts`, `tools/evaluator/__tests__/discoverer.test.ts`). [[1]](diffhunk://#diff-6d2765e2ae6fd687a0c02f40748b5f802fba31090f64e73f72cdd0b774734827L101-R101) [[2]](diffhunk://#diff-ce4978a844b684331cd4bc4b835846d315cd65f2fb7f3cc3bc4f7ba660ead88fL2-R2)